### PR TITLE
Adds listing of transfers on new-gw-notification

### DIFF
--- a/src/Slackbot.Net.Extensions.FplBot/Abstractions/ITransfersByGameWeek.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/Abstractions/ITransfersByGameWeek.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Slackbot.Net.Extensions.FplBot.Abstractions
+{
+    internal interface ITransfersByGameWeek
+    {
+        Task<string> GetTransfersByGameweek(int? gw);
+    }
+}

--- a/src/Slackbot.Net.Extensions.FplBot/Handlers/FplTransfersCommandHandler.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/Handlers/FplTransfersCommandHandler.cs
@@ -11,58 +11,28 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Slackbot.Net.Extensions.FplBot.Abstractions;
 
 namespace Slackbot.Net.Extensions.FplBot.Handlers
 {
     internal class FplTransfersCommandHandler : IHandleMessages
     {
-        private readonly FplbotOptions _fplbotOptions;
         private readonly IEnumerable<IPublisher> _publishers;
-        private readonly ITransfersClient _transfersClient;
-        private readonly IPlayerClient _playerClient;
-        private readonly ILeagueClient _leagueClient;
-        private readonly IEntryClient _entryClient;
         private readonly IGameweekHelper _gameweekHelper;
+        private readonly ITransfersByGameWeek _transfersClient;
 
-        public FplTransfersCommandHandler(
-            IEnumerable<IPublisher> publishers,
-            IOptions<FplbotOptions> options, 
-            ITransfersClient transfersClient, 
-            IPlayerClient playerClient, 
-            ILeagueClient leagueClient,
-            IEntryClient entryClient,
-            IGameweekHelper gameweekHelper)
+        public FplTransfersCommandHandler(IEnumerable<IPublisher> publishers, IGameweekHelper gameweekHelper, ITransfersByGameWeek transfersByGameweek)
         {
-            _fplbotOptions = options.Value;
             _publishers = publishers;
-            _transfersClient = transfersClient;
-            _playerClient = playerClient;
-            _leagueClient = leagueClient;
-            _entryClient = entryClient;
             _gameweekHelper = gameweekHelper;
+            _transfersClient = transfersByGameweek;
         }
 
         public async Task<HandleResponse> Handle(SlackMessage message)
         {
-            var leagueTask = _leagueClient.GetClassicLeague(_fplbotOptions.LeagueId);
-            var playersTask = _playerClient.GetAllPlayers();
-            var gameweekTask = _gameweekHelper.ExtractGameweekOrFallbackToCurrent(message.Text, "transfers {gw}");
-
-            var league = await leagueTask;
-            var players = await playersTask;
-            var gw = await gameweekTask;
-
-            var sb = new StringBuilder();
-            sb.Append($"Transfers made for gameweek {gw}:\n\n");
-
-            await Task.WhenAll(league.Standings.Entries
-                .OrderBy(x => x.Rank)
-                .Select(entry => GetTransfersTextForEntry(entry, gw.Value, players))
-                .ToArray()
-                .ForEach(async task => sb.Append(await task)));
-
-            var messageToSend = sb.ToString();
-
+            var gameweek = await _gameweekHelper.ExtractGameweekOrFallbackToCurrent(message.Text, "transfers {gw}");
+            var messageToSend = await _transfersClient.GetTransfersByGameweek(gameweek);
+            
             foreach (var p in _publishers)
             {
                 await p.Publish(new Notification
@@ -73,49 +43,6 @@ namespace Slackbot.Net.Extensions.FplBot.Handlers
             }
 
             return new HandleResponse(messageToSend);
-        }
-
-        private async Task<string> GetTransfersTextForEntry(ClassicLeagueEntry entry, int gameweek, ICollection<Player> players)
-        {
-            var transfersTask = _transfersClient.GetTransfers(entry.Entry);
-            var picksTask = _entryClient.GetPicks(entry.Entry, gameweek);
-
-            var transfers = (await transfersTask).Where(x => x.Event == gameweek).Select(x => new
-            {
-                EntryId = x.Entry,
-                PlayerTransferredOut = GetPlayerName(players, x.ElementOut),
-                PlayerTransferredIn = GetPlayerName(players, x.ElementIn),
-                SoldFor = x.ElementOutCost,
-                BoughtFor = x.ElementInCost
-            }).ToArray();
-
-            var sb = new StringBuilder();
-
-            sb.Append($"{entry.GetEntryLink(gameweek)} ");
-            if (transfers.Any())
-            {
-                var picks = await picksTask;
-                var transferCost = picks.EventEntryHistory.EventTransfersCost;
-                var wildcardPlayed = picks.ActiveChip == Constants.ChipNames.Wildcard;
-                var transferCostString = transferCost > 0 ? $" (-{transferCost} pts)" : wildcardPlayed ? " (:fire:wildcard:fire:)" : "";
-                sb.Append($"transferred{transferCostString}:\n");
-                foreach (var entryTransfer in transfers)
-                {
-                    sb.Append($"   {entryTransfer.PlayerTransferredOut} ({Formatter.FormatCurrency(entryTransfer.SoldFor)}) :arrow_right: {entryTransfer.PlayerTransferredIn} ({Formatter.FormatCurrency(entryTransfer.BoughtFor)})\n");
-                }
-            }
-            else
-            {
-                sb.Append("made no transfers :shrug:\n");
-            }
-
-            return sb.ToString();
-        }
-
-        private static string GetPlayerName(IEnumerable<Player> players, int playerId)
-        {
-            var player = players.SingleOrDefault(x => x.Id == playerId);
-            return player != null ? $"{player.FirstName} {player.SecondName}" : "";
         }
 
         public bool ShouldHandle(SlackMessage message) => message.MentionsBot && message.Text.Contains("transfers");

--- a/src/Slackbot.Net.Extensions.FplBot/Helpers/TransfersByGameWeek.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/Helpers/TransfersByGameWeek.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Fpl.Client.Abstractions;
+using Fpl.Client.Models;
+using Microsoft.Extensions.Options;
+using Slackbot.Net.Extensions.FplBot.Abstractions;
+using Slackbot.Net.Extensions.FplBot.Extensions;
+
+namespace Slackbot.Net.Extensions.FplBot.Helpers
+{
+    internal class TransfersByGameWeek : ITransfersByGameWeek
+    {
+        private readonly FplbotOptions _fplbotOptions;
+        private readonly ILeagueClient _leagueClient;
+        private readonly IPlayerClient _playerClient;
+        private readonly IGameweekHelper _gameweekHelper;
+        private readonly ITransfersClient _transfersClient;
+        private readonly IEntryClient _entryClient;
+
+        public TransfersByGameWeek(IOptions<FplbotOptions> fplbotOptions, 
+            ILeagueClient leagueClient,
+            IPlayerClient playerClient,
+            IGameweekHelper gameweekHelper,
+            ITransfersClient transfersClient,
+            IEntryClient entryClient
+            )
+        {
+            _fplbotOptions = fplbotOptions.Value;
+            _leagueClient = leagueClient;
+            _playerClient = playerClient;
+            _gameweekHelper = gameweekHelper;
+            _transfersClient = transfersClient;
+            _entryClient = entryClient;
+        }
+        
+        public async Task<string> GetTransfersByGameweek(int? gw)
+        {
+            var leagueTask = _leagueClient.GetClassicLeague(_fplbotOptions.LeagueId);
+            var playersTask = _playerClient.GetAllPlayers();
+
+            var league = await leagueTask;
+            var players = await playersTask;
+
+            var sb = new StringBuilder();
+            sb.Append($"Transfers made for gameweek {gw}:\n\n");
+
+            await Task.WhenAll(league.Standings.Entries
+                .OrderBy(x => x.Rank)
+                .Select(entry => GetTransfersTextForEntry(entry, gw.Value, players))
+                .ToArray()
+                .ForEach(async task => sb.Append(await task)));
+
+            return sb.ToString();
+        }
+        
+        private async Task<string> GetTransfersTextForEntry(ClassicLeagueEntry entry, int gameweek, ICollection<Player> players)
+        {
+            var transfersTask = _transfersClient.GetTransfers(entry.Entry);
+            var picksTask = _entryClient.GetPicks(entry.Entry, gameweek);
+
+            var transfers = (await transfersTask).Where(x => x.Event == gameweek).Select(x => new
+            {
+                EntryId = x.Entry,
+                PlayerTransferredOut = GetPlayerName(players, x.ElementOut),
+                PlayerTransferredIn = GetPlayerName(players, x.ElementIn),
+                SoldFor = x.ElementOutCost,
+                BoughtFor = x.ElementInCost
+            }).ToArray();
+
+            var sb = new StringBuilder();
+
+            sb.Append($"{entry.GetEntryLink(gameweek)} ");
+            if (transfers.Any())
+            {
+                var picks = await picksTask;
+                var transferCost = picks.EventEntryHistory.EventTransfersCost;
+                var wildcardPlayed = picks.ActiveChip == Constants.ChipNames.Wildcard;
+                var transferCostString = transferCost > 0 ? $" (-{transferCost} pts)" : wildcardPlayed ? " (:fire:wildcard:fire:)" : "";
+                sb.Append($"transferred{transferCostString}:\n");
+                foreach (var entryTransfer in transfers)
+                {
+                    sb.Append($"   {entryTransfer.PlayerTransferredOut} ({Formatter.FormatCurrency(entryTransfer.SoldFor)}) :arrow_right: {entryTransfer.PlayerTransferredIn} ({Formatter.FormatCurrency(entryTransfer.BoughtFor)})\n");
+                }
+            }
+            else
+            {
+                sb.Append("made no transfers :shrug:\n");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GetPlayerName(IEnumerable<Player> players, int playerId)
+        {
+            var player = players.SingleOrDefault(x => x.Id == playerId);
+            return player != null ? $"{player.FirstName} {player.SecondName}" : "";
+        }
+    }
+}

--- a/src/Slackbot.Net.Extensions.FplBot/SlackBotBuilderExtensions.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/SlackBotBuilderExtensions.cs
@@ -40,6 +40,7 @@ namespace Slackbot.Net.Abstractions.Hosting
         private static void AddCommon(this ISlackbotWorkerBuilder builder)
         {
             builder.Services.AddSingleton<ICaptainsByGameWeek, CaptainsByGameWeek>();
+            builder.Services.AddSingleton<ITransfersByGameWeek,TransfersByGameWeek>();
             builder.Services.AddSingleton<IChipsPlayed, ChipsPlayed>();
             builder.Services.AddSingleton<ITeamValue, TeamValue>();
             builder.Services.AddSingleton<IMessageHelper, MessageHelper>();


### PR DESCRIPTION
Trakk ut transfersforgameweek i en egen klasse for å gjenbruke i bakgrunnsjobb-tingen som kjører når en ny gameweek er i gang.

Håpet er å få captains + transfers som en del av "Ny gameweek"-alert.