### PR TITLE
Migrate to using Herokus REDIS_URL for configuration

### DIFF
--- a/src/FplBot.WebApi/Data/RedisOptions.cs
+++ b/src/FplBot.WebApi/Data/RedisOptions.cs
@@ -1,9 +1,25 @@
+using System;
+
 namespace FplBot.WebApi.Data
 {
     public class RedisOptions
     {
-        public string REDIS_SERVER { get; set; }
-        public string REDIS_USERNAME { get; set; }
-        public string REDIS_PASSWORD { get; set; }
+        public string REDIS_URL { get; set; } // Set by Heroku
+        public string GetRedisPassword => RedisUri().UserInfo.Split(":")[1];
+
+        public string GetRedisUsername => RedisUri().UserInfo.Split(":")[0];
+
+        public string GetRedisServerHostAndPort => REDIS_URL.Split("@")[1];
+
+        private Uri _uri;
+
+        private Uri RedisUri()
+        {
+            if (_uri == null)
+            {
+                _uri = new Uri(REDIS_URL);
+            }
+            return _uri;
+        }
     }
 }

--- a/src/FplBot.WebApi/Data/RedisSlackTeamRepository.cs
+++ b/src/FplBot.WebApi/Data/RedisSlackTeamRepository.cs
@@ -25,7 +25,7 @@ namespace FplBot.WebApi.Data
         {
             _redis = redis;
             _db = _redis.GetDatabase();
-            _server = redisOptions.Value.REDIS_SERVER;
+            _server = redisOptions.Value.GetRedisServerHostAndPort;
         }
         
         public async Task Insert(SlackTeam slackTeam)

--- a/src/FplBot.WebApi/Startup.cs
+++ b/src/FplBot.WebApi/Startup.cs
@@ -40,9 +40,14 @@ namespace FplBot.WebApi
             {
                 var opts = c.GetService<IOptions<RedisOptions>>().Value;
                 var logger = c.GetService<ILogger<Startup>>();
-                var connString = $"{opts.REDIS_SERVER}, name={opts.REDIS_USERNAME}, password={opts.REDIS_PASSWORD}";
-                logger.LogInformation(connString);
-                return ConnectionMultiplexer.Connect(connString);
+                var options = new ConfigurationOptions
+                {
+                    ClientName = opts.GetRedisUsername,
+                    Password = opts.GetRedisPassword,
+                    EndPoints = {opts.GetRedisServerHostAndPort}
+                };
+                logger.LogInformation(options.ToString());
+                return ConnectionMultiplexer.Connect(options);
             });
             services.AddSingleton<ISlackTeamRepository, RedisSlackTeamRepository>();
             services.Configure<AnalyticsOptions>(Configuration);


### PR DESCRIPTION
Moves to match name of injected secrets in Heroku, since Heroku updates these values when patching Redis instances and disregards our current custom ones.