### PR TITLE
Use a separate instance for integration tests

### DIFF
--- a/src/FplBot.WebApi.Tests/RedisIntegrationTests.cs
+++ b/src/FplBot.WebApi.Tests/RedisIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace FplBot.WebApi.Tests
             _helper = helper;
             var opts = new OptionsWrapper<RedisOptions>(new RedisOptions
             {
-                REDIS_URL = Environment.GetEnvironmentVariable("REDIS_URL_BLUE"),
+                REDIS_URL = Environment.GetEnvironmentVariable("HEROKU_REDIS_COPPER_URL"),
             });
 
             var configurationOptions = new ConfigurationOptions


### PR DESCRIPTION
The test suite will flush the entire db (delete all data), so using a sep redis instance for it to avoid deleting data for developers.

NB, redis integration tests are still skipped in the test suite. Waiting to enable it until everyone is working off latest in master.