### PR TITLE
Bugfix: Near deadline first gw

### DIFF
--- a/src/Slackbot.Net.Extensions.FplBot/RecurringActions/NearDeadlineRecurringAction.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/RecurringActions/NearDeadlineRecurringAction.cs
@@ -41,8 +41,7 @@ namespace Slackbot.Net.Extensions.FplBot.RecurringActions
             
             if (current == null)
             {
-                _logger.LogDebug($"No current gameweek");
-                return;
+                current = gweeks.First();
             }
 
             if(_dateTimeUtils.IsWithinMinutesToDate(_minutesBeforeDeadline, current.Deadline))


### PR DESCRIPTION
Uses first gw as current if none are current.