### PR TITLE
Refactor fixture-events handling into C# event handlers

### DIFF
--- a/src/Slackbot.Net.Extensions.FplBot/Abstractions/IState.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/Abstractions/IState.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Slackbot.Net.Endpoints.Models;
@@ -11,7 +12,8 @@ namespace Slackbot.Net.Extensions.FplBot.Abstractions
         Task Reset(int newGameweek);
         
         IEnumerable<SlackTeam> GetActiveTeams();
-        Task<IEnumerable<FixtureEvents>> Refresh(int gameweek);
+        Task Refresh(int gameweek);
         GameweekLeagueContext GetGameweekLeagueContext(string teamId);
+        event Func<IEnumerable<FixtureEvents>, Task> OnNewFixtureEvents;
     }
 }    

--- a/src/Slackbot.Net.Extensions.FplBot/GameweekLifecycle/Handlers/FixtureEventsHandler.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/GameweekLifecycle/Handlers/FixtureEventsHandler.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Slackbot.Net.Extensions.FplBot.Abstractions;
+using Slackbot.Net.Extensions.FplBot.Helpers;
+using Slackbot.Net.Extensions.FplBot.Models;
+
+namespace Slackbot.Net.Extensions.FplBot.GameweekLifecycle.Handlers
+{
+    public class FixtureEventsHandler
+    {
+        private readonly IState _state;
+        private readonly ISlackWorkSpacePublisher _publisher;
+
+        public FixtureEventsHandler(IState state, ISlackWorkSpacePublisher publisher)
+        {
+            _state = state;
+            _publisher = publisher;
+        }
+        
+        public async Task OnNewFixtureEvents(IEnumerable<FixtureEvents> newEvents)
+        {
+            foreach (var team in _state.GetActiveTeams())
+            {
+                var context = _state.GetGameweekLeagueContext(team.TeamId);
+                var formattedEvents = GameweekEventsFormatter.FormatNewFixtureEvents(newEvents.ToList(), context);
+                await _publisher.PublishToWorkspace(team.TeamId, team.FplBotSlackChannel, formattedEvents.ToArray());
+            }
+        }
+    }
+}

--- a/src/Slackbot.Net.Extensions.FplBot/GameweekLifecycle/Handlers/FixtureEventsMonitor.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/GameweekLifecycle/Handlers/FixtureEventsMonitor.cs
@@ -19,6 +19,7 @@ namespace Slackbot.Net.Extensions.FplBot.GameweekLifecycle.Handlers
             _publisher = publisher;
             _logger = logger;
             _state = state;
+            _state.OnNewFixtureEvents += HandleNewFixtureEvents;
         }
 
         public async Task Initialize(int gwId)
@@ -36,8 +37,7 @@ namespace Slackbot.Net.Extensions.FplBot.GameweekLifecycle.Handlers
         public async Task HandleGameweekOngoing(int currentGameweek)
         {
             _logger.LogInformation("Refreshing state");
-            var newEvents = await _state.Refresh(currentGameweek);
-            await HandleNewFixtureEvents(newEvents);
+            await _state.Refresh(currentGameweek);
         }
 
         private async Task HandleNewFixtureEvents(IEnumerable<FixtureEvents> newEvents)

--- a/src/Slackbot.Net.Extensions.FplBot/GameweekLifecycle/Handlers/FixtureEventsMonitor.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/GameweekLifecycle/Handlers/FixtureEventsMonitor.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Slackbot.Net.Extensions.FplBot.Abstractions;
 using Slackbot.Net.Extensions.FplBot.Helpers;
 using System.Linq;
 using System.Threading.Tasks;
+using Slackbot.Net.Extensions.FplBot.Models;
 
 namespace Slackbot.Net.Extensions.FplBot.GameweekLifecycle.Handlers
 {
@@ -35,7 +37,11 @@ namespace Slackbot.Net.Extensions.FplBot.GameweekLifecycle.Handlers
         {
             _logger.LogInformation("Refreshing state");
             var newEvents = await _state.Refresh(currentGameweek);
+            await HandleNewFixtureEvents(newEvents);
+        }
 
+        private async Task HandleNewFixtureEvents(IEnumerable<FixtureEvents> newEvents)
+        {
             if (newEvents.Any())
             {
                 _logger.LogInformation("New events!");

--- a/src/Slackbot.Net.Extensions.FplBot/GameweekLifecycle/Handlers/State.cs
+++ b/src/Slackbot.Net.Extensions.FplBot/GameweekLifecycle/Handlers/State.cs
@@ -80,7 +80,7 @@ namespace Slackbot.Net.Extensions.FplBot.GameweekLifecycle.Handlers
             return _activeSlackTeams;
         }
 
-        public async Task<IEnumerable<FixtureEvents>> Refresh(int currentGameweek)
+        public async Task Refresh(int currentGameweek)
         {
             await EnsureNewLeaguesAreMonitored(currentGameweek);
             
@@ -89,13 +89,12 @@ namespace Slackbot.Net.Extensions.FplBot.GameweekLifecycle.Handlers
             
             if (fixtureEvents.Any())
             {
+                await OnNewFixtureEvents(fixtureEvents.ToList());
                 _currentGameweekFixtures = latest;
             }
             _logger.LogInformation($"Active teams count: {_activeSlackTeams.Count()}");
             _logger.LogInformation($"Slack users count: {_slackUsers.Count}");
             _logger.LogInformation($"Transfers count: {_transfersForCurrentGameweekBySlackTeam.Count}");
-
-            return fixtureEvents;
         }
 
         public GameweekLeagueContext GetGameweekLeagueContext(string teamId)
@@ -123,6 +122,8 @@ namespace Slackbot.Net.Extensions.FplBot.GameweekLifecycle.Handlers
                 CurrentGameweek = _currentGameweek
             };
         }
+
+        public event Func<IEnumerable<FixtureEvents>, Task> OnNewFixtureEvents = fixtureEvents => Task.CompletedTask;
 
         private async Task EnsureNewLeaguesAreMonitored(int currentGameweek)
         {


### PR DESCRIPTION
Legger til rette for å håndtere andre ulike typer events ved bruk av C# event handlers, slik at de blir mest mulig uavhengige (minst mulige koblinger, eller try-catches). Tenkte f.eks. å legge til "player injurered" eventet i en senere PR.