### PR TITLE
Move out indexing search executed search terms to async handler

### DIFF
--- a/src/Fpl.Search/Fpl.Search.csproj
+++ b/src/Fpl.Search/Fpl.Search.csproj
@@ -9,12 +9,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="NEST" Version="7.10.0" />
+    <PackageReference Include="NServiceBus" Version="7.2.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
   </ItemGroup>
 
 
   <ItemGroup>
     <ProjectReference Include="..\Fpl.Client\Fpl.Client.csproj" />
+    <ProjectReference Include="..\FplBot.Messaging.Contracts\FplBot.Messaging.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Fpl.Search/Indexing/IIndexProvider.cs
+++ b/src/Fpl.Search/Indexing/IIndexProvider.cs
@@ -3,7 +3,7 @@ using Fpl.Search.Models;
 
 namespace Fpl.Search.Indexing
 {
-    public interface IIndexProvider<T> where T : IIndexableItem
+    public interface IIndexProvider<T> where T : class
     {
         string IndexName { get; }
         Task<int> StartIndexingFrom { get; }

--- a/src/Fpl.Search/Indexing/IndexingClient.cs
+++ b/src/Fpl.Search/Indexing/IndexingClient.cs
@@ -1,5 +1,4 @@
-﻿using Fpl.Search.Models;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Nest;
 using System.Collections.Generic;
 using System.Threading;
@@ -18,7 +17,7 @@ namespace Fpl.Search.Indexing
             _logger = logger;
         }
 
-        public async Task Index<T>(IEnumerable<T> items, string index, CancellationToken token) where T : class, IIndexableItem
+        public async Task Index<T>(IEnumerable<T> items, string index, CancellationToken token) where T : class
         {
             var response = await _elasticClient.IndexManyAsync(items, index, token);
             if (response.Errors)
@@ -33,6 +32,6 @@ namespace Fpl.Search.Indexing
 
     public interface IIndexingClient
     {
-        Task Index<T>(IEnumerable<T> items, string index, CancellationToken token) where T : class, IIndexableItem;
+        Task Index<T>(IEnumerable<T> items, string index, CancellationToken token) where T : class;
     }
 }

--- a/src/Fpl.Search/Indexing/IndexingService.cs
+++ b/src/Fpl.Search/Indexing/IndexingService.cs
@@ -36,7 +36,7 @@ namespace Fpl.Search.Indexing
             await Index(_leagueIndexProvider,pageProgress,token);
         }
 
-        private async Task Index<T>(IIndexProvider<T> indexProvider, Action<int> pageProgress, CancellationToken token) where T : class, IIndexableItem
+        private async Task Index<T>(IIndexProvider<T> indexProvider, Action<int> pageProgress, CancellationToken token) where T : class
         {
             var i = await indexProvider.StartIndexingFrom;
             var batchSize = 8;

--- a/src/Fpl.Search/Models/EntryItem.cs
+++ b/src/Fpl.Search/Models/EntryItem.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fpl.Search.Models
 {
-    public class EntryItem : IIndexableItem
+    public class EntryItem
     {
         public int Id { get; set; }
         public int Entry { get; set; }

--- a/src/Fpl.Search/Models/IIndexableItem.cs
+++ b/src/Fpl.Search/Models/IIndexableItem.cs
@@ -1,4 +1,0 @@
-﻿namespace Fpl.Search.Models
-{
-    public interface IIndexableItem { }
-}

--- a/src/Fpl.Search/Models/LeagueItem.cs
+++ b/src/Fpl.Search/Models/LeagueItem.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fpl.Search.Models
 {
-    public class LeagueItem : IIndexableItem
+    public class LeagueItem
     {
         public int Id { get; set; }
         public string Name { get; set; }

--- a/src/Fpl.Search/Models/QueryAnalyticsItem.cs
+++ b/src/Fpl.Search/Models/QueryAnalyticsItem.cs
@@ -2,20 +2,6 @@
 
 namespace Fpl.Search.Models
 {
-    public class QueryAnalyticsItem : IIndexableItem
-    {
-        public DateTime TimeStamp { get; set; }
-        public string Query { get; set; }
-        public string QueriedIndex { get; set; }
-        public string BoostedCountry { get; set; }
-        public long TotalHits { get; set; }
-        public long ResponseTimeMs { get; set; }
-        public string Client { get; set; }
-        public string Team { get; set; }
-        public string FollowingFplLeagueId { get; set; }
-        public string Actor { get; set; }
-    }
-
     public enum QueryClient
     {
         Slack,

--- a/src/Fpl.Search/Models/SearchResult.cs
+++ b/src/Fpl.Search/Models/SearchResult.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Fpl.Search.Models
 {
-    public class SearchResult<T> where T : IIndexableItem
+    public class SearchResult<T> where T : class
     {
         public IReadOnlyCollection<T> ExposedHits { get; }
         public long TotalHits { get; }

--- a/src/Fpl.Search/SearchServiceCollectionExtensions.cs
+++ b/src/Fpl.Search/SearchServiceCollectionExtensions.cs
@@ -30,7 +30,6 @@ namespace Fpl.Search
             services.AddSingleton<IIndexProvider<LeagueItem>, LeagueIndexProvider>();
             services.AddSingleton<IIndexBookmarkProvider, LeagueIndexBookmarkProvider>();
             services.AddSingleton<IIndexingService, IndexingService>();
-            services.AddSingleton<IQueryAnalyticsIndexingService, QueryAnalyticsIndexingService>();
 
             return services;
         }

--- a/src/Fpl.SearchConsole/Fpl.SearchConsole.csproj
+++ b/src/Fpl.SearchConsole/Fpl.SearchConsole.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.7.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Spectre.Console" Version="0.37.0" />

--- a/src/Fpl.SearchConsole/Program.cs
+++ b/src/Fpl.SearchConsole/Program.cs
@@ -5,6 +5,7 @@ using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 using Fpl.SearchConsole.Commands.Definitions;
 using Microsoft.Extensions.Hosting;
+using NServiceBus;
 using Serilog;
 
 namespace Fpl.SearchConsole
@@ -16,7 +17,14 @@ namespace Fpl.SearchConsole
             await BuildCommandLine()
                 .UseHost(_ => Host.CreateDefaultBuilder(args)
                                     .UseSerilog((_, conf) => conf.WriteTo.Console())
-                                    .ConfigureServices((_, services) => services.AddSearchConsole()))
+                                    .UseNServiceBus(ctx =>
+                                    {
+                                        var endpointConfiguration = new EndpointConfiguration($"Fpl.SearchConsole.{ctx.HostingEnvironment.EnvironmentName}");
+                                        endpointConfiguration.UseTransport<LearningTransport>();
+                                        return endpointConfiguration;
+                                    })
+                                    .ConfigureServices((_, services) => services.AddSearchConsole())
+                )
                 .UseDefaults()
                 .Build()
                 .InvokeAsync(args);

--- a/src/Fpl.SearchConsole/ServiceCollectionExtensions.cs
+++ b/src/Fpl.SearchConsole/ServiceCollectionExtensions.cs
@@ -27,7 +27,6 @@ namespace Fpl.SearchConsole
             services.AddSingleton<IConnectionSettingsValues>(conn);
             services.AddSingleton<IElasticClient, ElasticClient>();
             services.AddSingleton<IIndexingClient, IndexingClient>();
-            services.AddSingleton<IQueryAnalyticsIndexingService, QueryAnalyticsIndexingService>();
             services.AddHttpClient<ILeagueClient, LeagueClient>(_ => new LeagueClient(CreateHttpClient()));
             services.AddHttpClient<IEntryClient, EntryClient>(_ => new EntryClient(CreateHttpClient()));
             services.AddSingleton<IIndexBookmarkProvider, SimpleLeagueIndexBookmarkProvider>();

--- a/src/FplBot.Messaging.Contracts/Commands/v1/IndexQuery.cs
+++ b/src/FplBot.Messaging.Contracts/Commands/v1/IndexQuery.cs
@@ -1,0 +1,17 @@
+using System;
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Commands.v1
+{
+    public record IndexQuery (
+        DateTime TimeStamp,
+        string Query,
+        string QueriedIndex,
+        string BoostedCountry,
+        long TotalHits,
+        long ResponseTimeMs,
+        string Client,
+        string Team,
+        string FollowingFplLeagueId,
+        string Actor) : ICommand;
+}


### PR DESCRIPTION
Replaces synchronous indexing job of analytics with publishing a command onto Azure Service Bus

Other:
- Removes empty marker interface `IIndexableItem`
- Replace `QueryAnalyticsItem` with a message _command_ contract `IndexQuery` (index this query plz)
- Removes try-catch in indexing analytics method, since the message will end up on the error queue instead (indexing analytics will no longer fail the search function since the process now is async)