### PR TITLE
Update live scores for verified accounts during ongoing gw

### DIFF
--- a/src/FplBot.Core/Data/VerifiedEntriesRepository.cs
+++ b/src/FplBot.Core/Data/VerifiedEntriesRepository.cs
@@ -73,11 +73,29 @@ namespace FplBot.Core.Data
             await Task.WhenAll(tasks);
         }
 
-        public async Task UpdateStats(int entryId, VerifiedEntryStats verifiedEntryStats)
+        public async Task UpdateAllStats(int entryId, VerifiedEntryStats verifiedEntryStats)
         {
             var entry = await GetVerifiedEntry(entryId);
             var newEntry = entry with {EntryStats = verifiedEntryStats};
             await Insert(newEntry);// insert behaves as update
+        }
+
+        public async Task UpdateLiveStats(int entryId, VerifiedEntryPointsUpdate newStats)
+        {
+            var entry = await GetVerifiedEntry(entryId);
+            var verifiedEntryStats = entry.EntryStats with
+            {
+                CurrentGwTotalPoints = newStats.CurrentGwTotalPoints,
+                OverallRank = newStats.OverallRank,
+                PointsThisGw = newStats.PointsThisGw
+            };
+            
+            var newEntry = entry with
+            {
+                EntryStats = verifiedEntryStats
+            };
+
+            await Insert(newEntry); // insert behaves as update
         }
 
         private static HashEntry[] AllWriteFields(VerifiedEntry entry)
@@ -163,6 +181,11 @@ namespace FplBot.Core.Data
         string ViceCaptain,
         int Gameweek);
 
+    public record VerifiedEntryPointsUpdate(
+        int CurrentGwTotalPoints, 
+        int OverallRank, 
+        int PointsThisGw);
+
     public interface IVerifiedEntriesRepository
     {
         Task Insert(VerifiedEntry entry);
@@ -171,6 +194,7 @@ namespace FplBot.Core.Data
         
         Task Delete(int entryId);
         Task DeleteAll();
-        Task UpdateStats(int entryId, VerifiedEntryStats verifiedEntryStats);
+        Task UpdateAllStats(int entryId, VerifiedEntryStats verifiedEntryStats);
+        Task UpdateLiveStats(int entryId, VerifiedEntryPointsUpdate newStats);
     }
 }

--- a/src/FplBot.Core/Data/VerifiedEntriesRepository.cs
+++ b/src/FplBot.Core/Data/VerifiedEntriesRepository.cs
@@ -113,10 +113,15 @@ namespace FplBot.Core.Data
                 hashEntries.Add(new("lastGwTotalPoints", entry.EntryStats.LastGwTotalPoints));
                 hashEntries.Add(new("overAllRank", entry.EntryStats.OverallRank));
                 hashEntries.Add(new("pointsThisGw", entry.EntryStats.PointsThisGw));
-                hashEntries.Add(new("activeChip", !string.IsNullOrEmpty(entry.EntryStats?.ActiveChip) ? entry.EntryStats?.ActiveChip : string.Empty));
-                hashEntries.Add(new("captain", entry.EntryStats.Captain));
-                hashEntries.Add(new("viceCaptain", entry.EntryStats.ViceCaptain));
+                hashEntries.Add(new("activeChip", ValueOrStringEmpty(entry.EntryStats.ActiveChip)));
+                hashEntries.Add(new("captain", ValueOrStringEmpty(entry.EntryStats.Captain)));
+                hashEntries.Add(new("viceCaptain", ValueOrStringEmpty(entry.EntryStats.ViceCaptain)));
                 hashEntries.Add(new("gameweek", entry.EntryStats.Gameweek));
+
+                string ValueOrStringEmpty(string value)
+                {
+                    return !string.IsNullOrEmpty(value) ? value : string.Empty;
+                }
             }
 
             return hashEntries.ToArray();
@@ -137,7 +142,7 @@ namespace FplBot.Core.Data
                 "activeChip",
                 "captain",
                 "viceCaptain",
-                "gameweek",
+                "gameweek"
             };
         }
         

--- a/src/FplBot.Core/Handlers/FplEvents/FixtureFulltimeUpdateStatsHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/FixtureFulltimeUpdateStatsHandler.cs
@@ -20,7 +20,7 @@ namespace FplBot.Core.GameweekLifecycle.Handlers
 
         public async Task Handle(FixturesFinished notification, CancellationToken cancellationToken)
         {
-            await _mediator.Publish(new UpdateEntryStats(), cancellationToken);
+            await _mediator.Publish(new UpdateEntryLiveStats(), cancellationToken);
         }
     }
 }

--- a/src/FplBot.Core/Handlers/FplEvents/FixtureFulltimeUpdateStatsHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/FixtureFulltimeUpdateStatsHandler.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FplBot.Core.Handlers.InternalCommands;
+using FplBot.Core.Models;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace FplBot.Core.GameweekLifecycle.Handlers
+{
+    public class FixtureFulltimeUpdateStatsHandler : INotificationHandler<FixturesFinished>
+    {
+        private readonly IMediator _mediator;
+        private readonly ILogger<FixtureFulltimeUpdateStatsHandler> _logger;
+
+        public FixtureFulltimeUpdateStatsHandler(IMediator mediator, ILogger<FixtureFulltimeUpdateStatsHandler> logger)
+        {
+            _mediator = mediator;
+            _logger = logger;
+        }
+
+        public async Task Handle(FixturesFinished notification, CancellationToken cancellationToken)
+        {
+            await _mediator.Publish(new UpdateEntryStats(), cancellationToken);
+        }
+    }
+}

--- a/src/FplBot.Core/Handlers/FplEvents/GameweekEndedUpdateStatsHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/GameweekEndedUpdateStatsHandler.cs
@@ -17,7 +17,7 @@ namespace FplBot.Core.Handlers.FplEvents
 
         public async Task Handle(GameweekJustBegan notification, CancellationToken cancellationToken)
         {
-            var t1 = _mediator.Publish(new UpdateEntryStats(), cancellationToken);
+            var t1 = _mediator.Publish(new UpdateAllEntryStats(), cancellationToken);
             var t2 = _mediator.Publish(new UpdateSelfishStats(Gameweek : notification.Gameweek.Id), cancellationToken);
             await Task.WhenAll(t1, t2);
         }

--- a/src/FplBot.Core/Handlers/FplEvents/GameweekEndedUpdateStatsHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/GameweekEndedUpdateStatsHandler.cs
@@ -17,7 +17,7 @@ namespace FplBot.Core.Handlers.FplEvents
 
         public async Task Handle(GameweekJustBegan notification, CancellationToken cancellationToken)
         {
-            var t1 = _mediator.Publish(new UpdateEntryStats(Gameweek: notification.Gameweek.Id), cancellationToken);
+            var t1 = _mediator.Publish(new UpdateEntryStats(), cancellationToken);
             var t2 = _mediator.Publish(new UpdateSelfishStats(Gameweek : notification.Gameweek.Id), cancellationToken);
             await Task.WhenAll(t1, t2);
         }

--- a/src/FplBot.Core/Handlers/InternalCommands/UpdateEntryStatsCommandHandler.cs
+++ b/src/FplBot.Core/Handlers/InternalCommands/UpdateEntryStatsCommandHandler.cs
@@ -10,7 +10,7 @@ using MediatR;
 
 namespace FplBot.Core.Handlers.InternalCommands
 {
-    public record UpdateEntryStats(int Gameweek) : INotification;
+    public record UpdateEntryStats : INotification;
 
     public class UpdateEntryStatsCommandHandler : INotificationHandler<UpdateEntryStats>
     {

--- a/src/FplBot.Core/Handlers/InternalCommands/UpdateEntryStatsCommandHandler.cs
+++ b/src/FplBot.Core/Handlers/InternalCommands/UpdateEntryStatsCommandHandler.cs
@@ -10,9 +10,9 @@ using MediatR;
 
 namespace FplBot.Core.Handlers.InternalCommands
 {
-    public record UpdateEntryStats : INotification;
+    public record UpdateAllEntryStats : INotification;
 
-    public class UpdateEntryStatsCommandHandler : INotificationHandler<UpdateEntryStats>
+    public class UpdateEntryStatsCommandHandler : INotificationHandler<UpdateAllEntryStats>
     {
         private readonly IEntryHistoryClient _entryHistoryClient;
         private readonly IGlobalSettingsClient _settingsClient;
@@ -27,7 +27,7 @@ namespace FplBot.Core.Handlers.InternalCommands
             _entryClient = entryClient;
         }
 
-        public async Task Handle(UpdateEntryStats notification, CancellationToken cancellationToken)
+        public async Task Handle(UpdateAllEntryStats notification, CancellationToken cancellationToken)
         {
             var allEntries = await _verifiedEntriesRepository.GetAllVerifiedEntries();
             var settings = await _settingsClient.GetGlobalSettings();
@@ -35,7 +35,7 @@ namespace FplBot.Core.Handlers.InternalCommands
             foreach (var entry in allEntries)
             {
                 var newStats = await GetUpdatedStatsForEntry(entry, players);
-                await _verifiedEntriesRepository.UpdateStats(entry.EntryId, newStats);
+                await _verifiedEntriesRepository.UpdateAllStats(entry.EntryId, newStats);
             }
         }
 

--- a/src/FplBot.Core/Handlers/InternalCommands/UpdateOngoingStatsCommandHandler.cs
+++ b/src/FplBot.Core/Handlers/InternalCommands/UpdateOngoingStatsCommandHandler.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Fpl.Client.Abstractions;
+using Fpl.Client.Models;
+using FplBot.Core.Data;
+using MediatR;
+
+namespace FplBot.Core.Handlers.InternalCommands
+{
+    public record UpdateEntryLiveStats : INotification;
+    
+    public class UpdateOngoingStatsCommandHandler : INotificationHandler<UpdateEntryLiveStats>
+    {
+        private readonly IEntryHistoryClient _entryHistoryClient;
+        private readonly IVerifiedEntriesRepository _verifiedEntriesRepository;
+
+        public UpdateOngoingStatsCommandHandler(IEntryHistoryClient entryHistoryClient, IVerifiedEntriesRepository verifiedEntriesRepository)
+        {
+            _entryHistoryClient = entryHistoryClient;
+            _verifiedEntriesRepository = verifiedEntriesRepository;
+        }
+
+        public async Task Handle(UpdateEntryLiveStats notification, CancellationToken cancellationToken)
+        {
+            var allEntries = await _verifiedEntriesRepository.GetAllVerifiedEntries();
+            
+            foreach (var entry in allEntries)
+            {
+                var newStats = await GetLiveStatsForEntry(entry);
+                await _verifiedEntriesRepository.UpdateLiveStats(entry.EntryId, newStats);
+            }
+        }
+
+        private async Task<VerifiedEntryPointsUpdate> GetLiveStatsForEntry(VerifiedEntry entry)
+        {
+            var history = await _entryHistoryClient.GetHistory(entry.EntryId);
+            var latestReportedGameweek = history.GameweekHistory.LastOrDefault();
+            return new VerifiedEntryPointsUpdate(
+                CurrentGwTotalPoints: latestReportedGameweek.TotalPoints,
+                OverallRank: latestReportedGameweek.OverallRank ?? 0,
+                PointsThisGw: latestReportedGameweek.Points);
+        }
+    }
+}

--- a/src/FplBot.WebApi/Pages/Admin/Verified.cshtml
+++ b/src/FplBot.WebApi/Pages/Admin/Verified.cshtml
@@ -33,10 +33,15 @@
                 <input type="submit" value="Seed selfishness" class="btn btn-info"/>
             </form>
             
-            <form asp-page-handler="UpdateStats">
+            <form asp-page-handler="UpdateAllBaseStats">
                 @Html.AntiForgeryToken()
-                <input type="submit" value="Update base stats" class="btn btn-info"/>
+                <input type="submit" value="Update all base stats" class="btn btn-info"/>
             </form>
+            
+            <form asp-page-handler="UpdateLiveScoreStats">
+                @Html.AntiForgeryToken()
+                <input type="submit" value="Update only live score stats" class="btn btn-info"/>
+            </form>            
             
             <form asp-page-handler="IncrementSelfishStats">
                 @Html.AntiForgeryToken()

--- a/src/FplBot.WebApi/Pages/Admin/Verified.cshtml.cs
+++ b/src/FplBot.WebApi/Pages/Admin/Verified.cshtml.cs
@@ -71,7 +71,7 @@ namespace  FplBot.WebApi.Pages.Admin
         {
             var settings = await _settings.GetGlobalSettings();
             var gameweek = settings.Gameweeks.GetCurrentGameweek();
-            await _mediator.Publish(new UpdateEntryStats(Gameweek: gameweek.Id));
+            await _mediator.Publish(new UpdateEntryStats());
             TempData["msg"] += $"Base stats added using gw {gameweek.Id}!";
             return RedirectToPage("Verified");
         }

--- a/src/FplBot.WebApi/Pages/Admin/Verified.cshtml.cs
+++ b/src/FplBot.WebApi/Pages/Admin/Verified.cshtml.cs
@@ -71,7 +71,7 @@ namespace  FplBot.WebApi.Pages.Admin
         {
             var settings = await _settings.GetGlobalSettings();
             var gameweek = settings.Gameweeks.GetCurrentGameweek();
-            await _mediator.Publish(new UpdateEntryStats());
+            await _mediator.Publish(new UpdateAllEntryStats());
             TempData["msg"] += $"Base stats added using gw {gameweek.Id}!";
             return RedirectToPage("Verified");
         }

--- a/src/FplBot.WebApi/Pages/Admin/Verified.cshtml.cs
+++ b/src/FplBot.WebApi/Pages/Admin/Verified.cshtml.cs
@@ -67,11 +67,20 @@ namespace  FplBot.WebApi.Pages.Admin
             return RedirectToPage("Verified");
         }
 
-        public async Task<IActionResult> OnPostUpdateStats()
+        public async Task<IActionResult> OnPostUpdateAllBaseStats()
         {
             var settings = await _settings.GetGlobalSettings();
             var gameweek = settings.Gameweeks.GetCurrentGameweek();
             await _mediator.Publish(new UpdateAllEntryStats());
+            TempData["msg"] += $"Base stats added using gw {gameweek.Id}!";
+            return RedirectToPage("Verified");
+        }
+        
+        public async Task<IActionResult> OnPostUpdateLiveScoreStats()
+        {
+            var settings = await _settings.GetGlobalSettings();
+            var gameweek = settings.Gameweeks.GetCurrentGameweek();
+            await _mediator.Publish(new UpdateEntryLiveStats());
             TempData["msg"] += $"Base stats added using gw {gameweek.Id}!";
             return RedirectToPage("Verified");
         }


### PR DESCRIPTION
- Live stats updates are triggered by the FixtureFulltime event (good enough, often enough @skjelbek ?)
- Updates the following stats for all verified accounts:  CurrentGwTotalPoints, OverallRank, PointsThisGw

