### PR TITLE
Recoverability: Test queue instead of in-mem

### DIFF
--- a/src/Fpl.Workers/Events/PublicEvents.cs
+++ b/src/Fpl.Workers/Events/PublicEvents.cs
@@ -8,7 +8,6 @@ namespace FplBot.Core.Models
     // Public events using in-mem MediatR handling:
     public record TwentyFourHoursToDeadline(Gameweek Gameweek) : INotification;
     public record OneHourToDeadline(Gameweek Gameweek) : INotification;
-    public record PriceChangeOccured(IEnumerable<PlayerUpdate> PlayerWithPriceChanges) : INotification;
     public record InjuryUpdateOccured(IEnumerable<PlayerUpdate> PlayersWithInjuryUpdates) : INotification;
     public record GameweekJustBegan(Gameweek Gameweek) : INotification;
     public record LineupReady(Lineups Lineups) : INotification;

--- a/src/Fpl.Workers/Events/PublicEvents.cs
+++ b/src/Fpl.Workers/Events/PublicEvents.cs
@@ -5,12 +5,11 @@ using System.Collections.Generic;
 
 namespace FplBot.Core.Models
 {
-    // Public events:
+    // Public events using in-mem MediatR handling:
     public record TwentyFourHoursToDeadline(Gameweek Gameweek) : INotification;
     public record OneHourToDeadline(Gameweek Gameweek) : INotification;
     public record PriceChangeOccured(IEnumerable<PlayerUpdate> PlayerWithPriceChanges) : INotification;
     public record InjuryUpdateOccured(IEnumerable<PlayerUpdate> PlayersWithInjuryUpdates) : INotification;
-    public record NewPlayersRegistered(IEnumerable<NewPlayer> NewPlayers) : INotification;
     public record GameweekJustBegan(Gameweek Gameweek) : INotification;
     public record LineupReady(Lineups Lineups) : INotification;
     public record FixtureEventsOccured(FixtureUpdates FixtureEvents) : INotification;

--- a/src/Fpl.Workers/Fpl.Workers.csproj
+++ b/src/Fpl.Workers/Fpl.Workers.csproj
@@ -8,10 +8,12 @@
     <PackageReference Include="CronBackgroundServices" Version="$(SlackbotNetVersion)" />
     <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="NServiceBus" Version="7.2.0" />
   </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\Fpl.Client\Fpl.Client.csproj" />
+    <ProjectReference Include="..\FplBot.Messaging.Contracts\FplBot.Messaging.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Fpl.Workers/Models/Mappers/PlayerChangesEventsExtractor.cs
+++ b/src/Fpl.Workers/Models/Mappers/PlayerChangesEventsExtractor.cs
@@ -10,15 +10,26 @@ namespace FplBot.Core.Helpers
     public class PlayerChangesEventsExtractor
     {
 
-        public static IEnumerable<PlayerUpdate> GetPriceChanges(ICollection<Player> after, ICollection<Player> players, ICollection<Team> teams)
+        public static IEnumerable<PlayerWithPriceChange> GetPriceChanges(ICollection<Player> after, ICollection<Player> players, ICollection<Team> teams)
         {
             if(players == null)
-                return new List<PlayerUpdate>();
+                return new List<PlayerWithPriceChange>();
 
             if (after == null)
-                return new List<PlayerUpdate>();
+                return new List<PlayerWithPriceChange>();
 
-            return ComparePlayers(after, players, teams, new PlayerPriceComparer());
+            var compared = ComparePlayers(after, players, teams, new PlayerPriceComparer());
+            return compared.Select(p => new PlayerWithPriceChange
+            {
+                PlayerId = p.ToPlayer.Id,
+                FirstName = p.ToPlayer.FirstName,
+                SecondName = p.ToPlayer.SecondName,
+                NowCost = p.ToPlayer.NowCost,
+                OwnershipPercentage = p.ToPlayer.OwnershipPercentage,
+                CostChangeEvent = p.ToPlayer.CostChangeEvent,
+                TeamId = p.Team.Id,
+                TeamShortName = p.Team.ShortName
+            });
         }
 
         public static IEnumerable<PlayerUpdate> GetInjuryUpdates(ICollection<Player> after, ICollection<Player> players, ICollection<Team> teams)

--- a/src/Fpl.Workers/Models/Mappers/PlayerChangesEventsExtractor.cs
+++ b/src/Fpl.Workers/Models/Mappers/PlayerChangesEventsExtractor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Fpl.Client.Models;
 using FplBot.Core.Helpers.Comparers;
 using FplBot.Core.Models;
+using FplBot.Messaging.Contracts.Events.v1;
 
 namespace FplBot.Core.Helpers
 {
@@ -45,8 +46,11 @@ namespace FplBot.Core.Helpers
 
             var updates = diff.Select(newPlayer => new NewPlayer
             {
-                Player = newPlayer,
-                Team = teams.FirstOrDefault(t => t.Code == newPlayer.TeamCode),
+                PlayerId = newPlayer.Id,
+                WebName = newPlayer.WebName,
+                NowCost = newPlayer.NowCost,
+                TeamId = teams.FirstOrDefault(t => t.Code == newPlayer.TeamCode).Id,
+                TeamShortName = teams.FirstOrDefault(t => t.Code == newPlayer.TeamCode).Name
             });
             return updates;
         }

--- a/src/Fpl.Workers/Models/PlayerUpdate.cs
+++ b/src/Fpl.Workers/Models/PlayerUpdate.cs
@@ -14,10 +14,4 @@ namespace FplBot.Core.Models
             toStatus = ToPlayer?.Status;
         }
     }
-
-    public class NewPlayer
-    {
-        public Player Player { get; set; }
-        public Team Team { get; set; }
-    }
 }

--- a/src/Fpl.Workers/States/State.cs
+++ b/src/Fpl.Workers/States/State.cs
@@ -3,11 +3,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Fpl.Client.Abstractions;
 using Fpl.Client.Models;
-using FplBot.Core.Abstractions;
 using FplBot.Core.Helpers;
 using FplBot.Core.Models;
+using FplBot.Messaging.Contracts.Events.v1;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using NServiceBus;
 
 namespace FplBot.Core.GameweekLifecycle
 {
@@ -16,6 +17,7 @@ namespace FplBot.Core.GameweekLifecycle
         private readonly IFixtureClient _fixtureClient;
         private readonly IGlobalSettingsClient _settingsClient;
         private readonly IMediator _mediator;
+        private readonly IMessageSession _session;
         private readonly ILogger<State> _logger;
 
         private ICollection<Player> _players;
@@ -23,11 +25,12 @@ namespace FplBot.Core.GameweekLifecycle
         private ICollection<Team> _teams;
         private int? _currentGameweek;
 
-        public State(IFixtureClient fixtureClient,IGlobalSettingsClient settingsClient, IMediator mediator, ILogger<State> logger = null)
+        public State(IFixtureClient fixtureClient,IGlobalSettingsClient settingsClient, IMediator mediator, IMessageSession session, ILogger<State> logger = null)
         {
             _fixtureClient = fixtureClient;
             _settingsClient = settingsClient;
             _mediator = mediator;
+            _session = session;
             _logger = logger;
 
             _currentGameweekFixtures = new List<Fixture>();
@@ -81,7 +84,7 @@ namespace FplBot.Core.GameweekLifecycle
                 await _mediator.Publish(new FixturesFinished(finishedFixtures.ToList()));
 
             if (newPlayers.Any())
-                await _mediator.Publish(new NewPlayersRegistered(newPlayers));
+                await _session.Publish(new NewPlayersRegistered(newPlayers));
         }
     }
 }

--- a/src/Fpl.Workers/States/State.cs
+++ b/src/Fpl.Workers/States/State.cs
@@ -75,7 +75,7 @@ namespace FplBot.Core.GameweekLifecycle
             }
 
             if (priceChanges.Any())
-                await _mediator.Publish(new PriceChangeOccured(priceChanges));
+                await _session.Publish(new PlayersPriceChanged { PlayersWithPriceChanges = priceChanges.ToList() });
 
             if (injuryUpdates.Any())
                 await _mediator.Publish(new InjuryUpdateOccured(injuryUpdates));

--- a/src/FplBot.Core/Handlers/FplEvents/PriceChangeHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/PriceChangeHandler.cs
@@ -1,18 +1,18 @@
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FplBot.Core.Abstractions;
 using FplBot.Core.Extensions;
 using FplBot.Core.Helpers;
-using FplBot.Core.Models;
 using FplBot.Data.Abstractions;
 using FplBot.Data.Models;
-using MediatR;
+using FplBot.Messaging.Contracts.Commands.v1;
+using FplBot.Messaging.Contracts.Events.v1;
 using Microsoft.Extensions.Logging;
+using NServiceBus;
 
 namespace FplBot.Core.GameweekLifecycle.Handlers
 {
-    public class PriceChangeHandler : INotificationHandler<PriceChangeOccured>
+    public class PriceChangeHandler : IHandleMessages<PlayersPriceChanged>, IHandleMessages<PublishPriceChangesToSlackWorkspace>
     {
         private readonly ISlackWorkSpacePublisher _publisher;
         private readonly ISlackTeamRepository _slackTeamRepo;
@@ -25,25 +25,32 @@ namespace FplBot.Core.GameweekLifecycle.Handlers
             _logger = logger;
         }
 
-        public async Task Handle(PriceChangeOccured notification, CancellationToken cancellationToken)
+        public async Task Handle(PlayersPriceChanged notification, IMessageHandlerContext context)
         {
-            _logger.LogInformation($"Handling {notification.PlayerWithPriceChanges.Count()} price updates");
+            _logger.LogInformation($"Handling {notification.PlayersWithPriceChanges.Count()} price updates");
             var slackTeams = await _slackTeamRepo.GetAllTeams();
             foreach (var slackTeam in slackTeams)
             {
                 if (slackTeam.Subscriptions.ContainsSubscriptionFor(EventSubscription.PriceChanges))
                 {
-                    var filtered = notification.PlayerWithPriceChanges.Where(c => c.ToPlayer.IsRelevant());
-                    if (filtered.Any())
-                    {
-                        var formatted = Formatter.FormatPriceChanged(filtered);
-                        await _publisher.PublishToWorkspace(slackTeam.TeamId, slackTeam.FplBotSlackChannel, formatted);
-                    }
-                    else
-                    {
-                        _logger.LogInformation("All price changes are all irrelevant, so not sending any notification");
-                    }
+                    await context.SendLocal(new PublishPriceChangesToSlackWorkspace { WorkspaceId = slackTeam.TeamId, PlayersWithPriceChanges = notification.PlayersWithPriceChanges.ToList() });
                 }
+            }
+        }
+
+        public async Task Handle(PublishPriceChangesToSlackWorkspace message, IMessageHandlerContext context)
+        {
+            _logger.LogInformation($"Publish price changes to {message.WorkspaceId}");
+            var filtered = message.PlayersWithPriceChanges.Where(c => c.OwnershipPercentage > 7);
+            if (filtered.Any())
+            {
+                var slackTeam = await _slackTeamRepo.GetTeam(message.WorkspaceId);
+                var formatted = Formatter.FormatPriceChanged(message.PlayersWithPriceChanges);
+                await _publisher.PublishToWorkspace(slackTeam.TeamId, slackTeam.FplBotSlackChannel, formatted);
+            }
+            else
+            {
+                _logger.LogInformation("All price changes were irrelevant, so not sending any notification");
             }
         }
     }

--- a/src/FplBot.Core/Helpers/Formatting/Formatter.cs
+++ b/src/FplBot.Core/Helpers/Formatting/Formatter.cs
@@ -10,6 +10,7 @@ using Fpl.Search.Models;
 using FplBot.Core.Extensions;
 using FplBot.Core.Models;
 using FplBot.Data.Models;
+using FplBot.Messaging.Contracts.Events.v1;
 using Slackbot.Net.Models.BlockKit;
 
 namespace FplBot.Core.Helpers
@@ -305,7 +306,7 @@ namespace FplBot.Core.Helpers
 
             string NameAndCost(NewPlayer p)
             {
-                return $"{p.Player.WebName} ({p.Team.ShortName}) {FormatCurrency(p.Player.NowCost)}";
+                return $"{p.WebName} ({p.TeamShortName}) {FormatCurrency(p.NowCost)}";
             }
         }
 

--- a/src/FplBot.Core/Helpers/Formatting/Formatter.cs
+++ b/src/FplBot.Core/Helpers/Formatting/Formatter.cs
@@ -310,13 +310,13 @@ namespace FplBot.Core.Helpers
             }
         }
 
-        public static string FormatPriceChanged(IEnumerable<PlayerUpdate> priceChangesPlayers)
+        public static string FormatPriceChanged(IEnumerable<PlayerWithPriceChange> priceChangesPlayers)
         {
             if (!priceChangesPlayers.Any())
                 return "No players with price changes.";
 
             var messageToSend = "";
-            var grouped = priceChangesPlayers.OrderByDescending(p => p.ToPlayer.CostChangeEvent).ThenByDescending(p => p.ToPlayer.NowCost).GroupBy(p => p.ToPlayer.CostChangeEvent);
+            var grouped = priceChangesPlayers.OrderByDescending(p => p.CostChangeEvent).ThenByDescending(p => p.NowCost).GroupBy(p => p.CostChangeEvent);
             foreach (var group in grouped)
             {
                 var priceChange = $"{FormatCurrency(group.Key)}";
@@ -330,7 +330,7 @@ namespace FplBot.Core.Helpers
                 messageToSend += $"\n\n{header}";
                 foreach (var p in group)
                 {
-                    messageToSend += $"\n• {p.ToPlayer.FirstName} {p.ToPlayer.SecondName} ({p.Team.ShortName}) {FormatCurrency(p.ToPlayer.NowCost)}";
+                    messageToSend += $"\n• {p.FirstName} {p.SecondName} ({p.TeamShortName}) {FormatCurrency(p.NowCost)}";
                 }
             }
 

--- a/src/FplBot.Messaging.Contracts/Commands/v1/PublishNewPlayersToSlackWorkspace.cs
+++ b/src/FplBot.Messaging.Contracts/Commands/v1/PublishNewPlayersToSlackWorkspace.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using FplBot.Messaging.Contracts.Events.v1;
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Commands.v1
+{
+    public class PublishNewPlayersToSlackWorkspace : ICommand
+    {
+        public IEnumerable<NewPlayer> NewPlayers { get; }
+        public string WorkspaceId { get; }
+
+        public PublishNewPlayersToSlackWorkspace(string workspaceId, IEnumerable<NewPlayer> newPlayers)
+        {
+            NewPlayers = newPlayers;
+            WorkspaceId = workspaceId;
+        }
+    }
+}

--- a/src/FplBot.Messaging.Contracts/Commands/v1/PublishPriceChangesToSlackWorkspace.cs
+++ b/src/FplBot.Messaging.Contracts/Commands/v1/PublishPriceChangesToSlackWorkspace.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Linq;
+using FplBot.Messaging.Contracts.Events.v1;
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Commands.v1
+{
+    public class PublishPriceChangesToSlackWorkspace : ICommand
+    {
+        public string WorkspaceId { get; set; }
+        public List<PlayerWithPriceChange> PlayersWithPriceChanges { get; set; }
+    }
+}

--- a/src/FplBot.Messaging.Contracts/Events/v1/NewPlayersRegistered.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/NewPlayersRegistered.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Events.v1
+{
+    public class NewPlayersRegistered : IEvent
+    {
+        public List<NewPlayer> NewPlayers { get; }
+
+        public NewPlayersRegistered(IEnumerable<NewPlayer> newPlayers)
+        {
+            NewPlayers = newPlayers.ToList();
+        }
+    }
+
+    public class NewPlayer
+    {
+        public int PlayerId { get; set; }
+        public string WebName { get; set; }
+        public int NowCost { get; set; }
+
+        public long TeamId { get; set; }
+        public string TeamShortName { get; set; }
+    }
+}

--- a/src/FplBot.Messaging.Contracts/Events/v1/PlayersPriceChanged.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/PlayersPriceChanged.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Events.v1
+{
+    public class PlayersPriceChanged : IEvent
+    {
+        public List<PlayerWithPriceChange> PlayersWithPriceChanges { get; set; }
+    }
+
+    public class PlayerWithPriceChange
+    {
+        public int PlayerId { get; set; }
+        public string FirstName { get; set; }
+        public string SecondName { get; set; }
+        public int CostChangeEvent { get; set; }
+        public int NowCost { get; set; }
+        public double OwnershipPercentage { get; set; }
+
+        public long TeamId { get; set; }
+        public string TeamShortName { get; set; }
+    }
+}

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -11,6 +11,8 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
         <PackageReference Include="FakeItEasy" Version="5.5.0" />
+      <PackageReference Include="NServiceBus.Testing" Version="7.2.0" />
+        <PackageReference Include="NServiceBus.Testing.Fakes.Sources" Version="7.1.13" />
     </ItemGroup>
 
     <ItemGroup Condition="Exists('appsettings.Local.json')">

--- a/src/FplBot.Tests/Helpers/TestBuilder.cs
+++ b/src/FplBot.Tests/Helpers/TestBuilder.cs
@@ -118,6 +118,7 @@ namespace FplBot.Tests
             return new Team
             {
                 Id = HomeTeamId,
+                Code = HomeTeamId,
                 ShortName = "HoMeTeam"
             };
         }
@@ -127,6 +128,7 @@ namespace FplBot.Tests
             return new Team
             {
                 Id = AwayTeamId,
+                Code = AwayTeamId,
                 ShortName = "AwAyTeam"
             };
         }
@@ -148,7 +150,8 @@ namespace FplBot.Tests
                 Id = PlayerId,
                 Code = PlayerCode,
                 FirstName = "PlayerFirstName",
-                SecondName = "PlayerSecondName"
+                SecondName = "PlayerSecondName",
+                TeamCode = HomeTeamId
             };
         }
 
@@ -159,7 +162,8 @@ namespace FplBot.Tests
                 Id = OtherPlayerId,
                 Code = OtherPlayerCode,
                 FirstName = "OtherPlayerFirstName",
-                SecondName = "OtherPlayerSecondName"
+                SecondName = "OtherPlayerSecondName",
+                TeamCode = AwayTeamId
             };
         }
 

--- a/src/FplBot.Tests/PriceMonitorTests.cs
+++ b/src/FplBot.Tests/PriceMonitorTests.cs
@@ -15,18 +15,18 @@ namespace FplBot.Tests
         {
             _helper = helper;
         }
-        
+
         [Fact]
         public void GetChangedPlayers_WhenNoPlayers_ReturnsNoChanges()
         {
             var before = new List<Player>{ };
             var after = new List<Player>{ };
-            
+
             var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after,before, new List<Team>());
-            
+
             Assert.Empty(priceChanges);
         }
-        
+
         [Fact]
         public void GetChangedPlayers_WhenSamePlayersWithPriceChange_ReturnsNoChanges()
         {
@@ -34,48 +34,48 @@ namespace FplBot.Tests
             var after = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(1) };
 
             var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after,before, new List<Team>());
-            
+
             Assert.Empty(priceChanges);
         }
-        
+
         [Fact]
         public void GetChangedPlayers_WhenSamePlayersWithChangeInPriceChange_ReturnsChanges()
         {
             var before = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(0) };
             var after = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(1) };
-            
-            var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after,before, new List<Team>());
+
+            var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after,before, new List<Team> { TestBuilder.HomeTeam(), TestBuilder.AwayTeam()});
 
             Assert.Single(priceChanges);
-            Assert.Equal(TestBuilder.Player().SecondName, priceChanges.First().ToPlayer.SecondName);
+            Assert.Equal(TestBuilder.Player().SecondName, priceChanges.First().SecondName);
         }
-        
+
         [Fact]
         public void GetChangedPlayers_WhenSamePlayersDuplicateWithChangeInPriceChange_ReturnsSingleChanges()
         {
             var before = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(0) };
             var after = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(1), TestBuilder.Player().WithCostChangeEvent(1) };
-            
-            var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after,before, new List<Team>());
+
+            var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after,before, new List<Team> { TestBuilder.HomeTeam(), TestBuilder.AwayTeam()});
 
             Assert.Single(priceChanges);
-            Assert.Equal(TestBuilder.Player().SecondName, priceChanges.First().ToPlayer.SecondName);
-            
+            Assert.Equal(TestBuilder.Player().SecondName, priceChanges.First().SecondName);
+
             var before2 = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(0), TestBuilder.Player().WithCostChangeEvent(0) };
             var after2 = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(1), TestBuilder.Player().WithCostChangeEvent(1) };
-            
-            var priceChanges2 = PlayerChangesEventsExtractor.GetPriceChanges(after2,before2, new List<Team>());
+
+            var priceChanges2 = PlayerChangesEventsExtractor.GetPriceChanges(after2,before2, new List<Team> { TestBuilder.HomeTeam(), TestBuilder.AwayTeam()});
 
             Assert.Single(priceChanges2);
-            Assert.Equal(TestBuilder.Player().SecondName, priceChanges2.First().ToPlayer.SecondName);
-            
+            Assert.Equal(TestBuilder.Player().SecondName, priceChanges2.First().SecondName);
+
             var before3 = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(0), TestBuilder.Player().WithCostChangeEvent(0) };
             var after3 = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(1) };
-            
-            var priceChanges3 = PlayerChangesEventsExtractor.GetPriceChanges(after3,before3, new List<Team>());
+
+            var priceChanges3 = PlayerChangesEventsExtractor.GetPriceChanges(after3,before3, new List<Team> { TestBuilder.HomeTeam(), TestBuilder.AwayTeam()});
 
             Assert.Single(priceChanges3);
-            Assert.Equal(TestBuilder.Player().SecondName, priceChanges3.First().ToPlayer.SecondName);
+            Assert.Equal(TestBuilder.Player().SecondName, priceChanges3.First().SecondName);
         }
 
         [Fact]
@@ -83,12 +83,12 @@ namespace FplBot.Tests
         {
             var before = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(1) };
             var after = new List<Player>{ TestBuilder.Player().WithCostChangeEvent(0) };
-            
-            var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after,before, new List<Team> { new Team()});
-            _helper.WriteLine(Formatter.FormatPriceChanged(priceChanges));
+
+            var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after,before, new List<Team> { TestBuilder.HomeTeam(), TestBuilder.AwayTeam()});
+
             Assert.Single(priceChanges);
         }
-        
+
         [Fact]
         public void GetChangedPlayers_OneNewPlayerWithCostChange_ReturnsNewPlayer()
         {
@@ -99,12 +99,12 @@ namespace FplBot.Tests
                 TestBuilder.OtherPlayer().WithCostChangeEvent(1)
             };
 
-            var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after, before, new List<Team>());
+            var priceChanges = PlayerChangesEventsExtractor.GetPriceChanges(after, before, new List<Team> { TestBuilder.HomeTeam(), TestBuilder.AwayTeam()});
 
             Assert.Single(priceChanges);
-            Assert.Equal(TestBuilder.OtherPlayer().SecondName, priceChanges.First().ToPlayer.SecondName);
+            Assert.Equal(TestBuilder.OtherPlayer().SecondName, priceChanges.First().SecondName);
         }
-        
+
         [Fact]
         public void GetChangedPlayers_OnePlayerRemoved_ReturnsNoChanges()
         {
@@ -113,7 +113,7 @@ namespace FplBot.Tests
                 TestBuilder.Player().WithCostChangeEvent(1),
                 TestBuilder.OtherPlayer().WithCostChangeEvent(1)
             };
-            
+
             var after = new List<Player>
             {
                 TestBuilder.Player().WithCostChangeEvent(1)

--- a/src/FplBot.Tests/StateTests.cs
+++ b/src/FplBot.Tests/StateTests.cs
@@ -1,17 +1,15 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FakeItEasy;
 using Fpl.Client.Abstractions;
 using Fpl.Client.Models;
-using FplBot.Core.Abstractions;
 using FplBot.Core.GameweekLifecycle;
 using FplBot.Core.Models;
 using FplBot.Data.Abstractions;
 using FplBot.Data.Models;
 using MediatR;
-using Microsoft.Extensions.Logging;
+using NServiceBus;
 using Xunit;
 
 namespace FplBot.Tests
@@ -105,7 +103,7 @@ namespace FplBot.Tests
         private static State CreateAllMockState()
         {
             _Mediator = A.Fake<IMediator>();
-            return new State(A.Fake<IFixtureClient>(),A.Fake<IGlobalSettingsClient>(), _Mediator);
+            return new State(A.Fake<IFixtureClient>(),A.Fake<IGlobalSettingsClient>(), _Mediator, A.Fake<IMessageSession>());
         }
 
         private static State CreateMultipleFinishedFixturesScenario()
@@ -380,7 +378,7 @@ namespace FplBot.Tests
                 TestBuilder.SlackTeam()
             });
             _Mediator = A.Fake<IMediator>();
-            return new State(fixtureClient, settingsClient, _Mediator);
+            return new State(fixtureClient, settingsClient, _Mediator, A.Fake<IMessageSession>());
         }
 
 


### PR DESCRIPTION
**Goal**: _Using some events as a test of using nservicebus for handling scale and fault tolerance._

- Moves 2 "less important" notifications to use nservicebus instead of mediatr to try it out
- This PR splits the current sequential slack publishing (foreach worskspace -> publish) into separate commands, allowing for both scale out and fault tolerance.

Ex: 
1. The worker process submits a single "newplayersevent" onto the queue.
2. A listener to the event consumes it, and publishes 1 new command pr slack: "publishnewplayerstoworkspace".
3. A listener to the command creates the formatted slack message and executes the publishing to the single workspace.

This approach might look more verbose/chatty, but is more decoupled, fault tolerant and rigged for scale. 

**Fault taulerance**
By default, nservicebus includes 5 immediate retries + 3 delayed retries (at 10s, then 20s, lastly 30s), but this is configurable later as we see fit. 

If an exception occurs when publishing to a single workspace, that individual operation/command will first be retried (immediate+delayed), and will be put onto the error queue if it still fails after that. A message on the error queue may be retried manually, if we want to. If we want to retry a message from the error queue, it would have to be manually decided. It might not make sense to re-try goals/assists 1 hour/day after the occurred. Other types of events might make sense even with a non-significant delay, like captains/transfers or standings.

**Scaling**
Processing of commands are also done concurrently, meaning we would go from delivering slack messages sequentially to in parallell. As of now, the endpoint processing these 2 events are still in the WebAPI host, but in the future we could move them to the Azure Function for offloading work.



