### PR TITLE
Move injury notifications to ASB transport

### DIFF
--- a/src/Fpl.Workers/Events/PublicEvents.cs
+++ b/src/Fpl.Workers/Events/PublicEvents.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 namespace FplBot.Core.Models
 {
     // Public events using in-mem MediatR handling:
-    public record InjuryUpdateOccured(IEnumerable<PlayerUpdate> PlayersWithInjuryUpdates) : INotification;
     public record GameweekJustBegan(Gameweek Gameweek) : INotification;
     public record FixtureEventsOccured(FixtureUpdates FixtureEvents) : INotification;
     public record FixturesFinished(IEnumerable<FinishedFixture> FinishedFixture) : INotification;

--- a/src/Fpl.Workers/Models/Mappers/PlayerChangesEventsExtractor.cs
+++ b/src/Fpl.Workers/Models/Mappers/PlayerChangesEventsExtractor.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using Fpl.Client.Models;
 using FplBot.Core.Helpers.Comparers;

--- a/src/Fpl.Workers/Models/Mappers/PlayerChangesEventsExtractor.cs
+++ b/src/Fpl.Workers/Models/Mappers/PlayerChangesEventsExtractor.cs
@@ -99,14 +99,13 @@ namespace FplBot.Core.Helpers
                 var fromPlayer = players.FirstOrDefault(p => p.Id == player.Id);
                 if (fromPlayer != null)
                 {
-                    Team? team = teams.FirstOrDefault(t => t.Code == player.TeamCode);
+                    Team team = teams.FirstOrDefault(t => t.Code == player.TeamCode);
                     updates.Add(new InjuredPlayerUpdate
                     (
-                        new InjuredPlayer(fromPlayer.Id, fromPlayer.WebName, fromPlayer.OwnershipPercentage),
+                        new InjuredPlayer(fromPlayer.Id, fromPlayer.WebName, fromPlayer.OwnershipPercentage, new TeamDescription(team.Id, team.ShortName, team.Name)),
                         new InjuryStatus(fromPlayer.Status, fromPlayer.News),
-                        new InjuryStatus(player.Status, player.News),
-                        new TeamDescription(team.Id, team.ShortName, team.Name))
-                    );
+                        new InjuryStatus(player.Status, player.News)
+                    ));
                 }
             }
 

--- a/src/Fpl.Workers/States/State.cs
+++ b/src/Fpl.Workers/States/State.cs
@@ -78,7 +78,7 @@ namespace FplBot.Core.GameweekLifecycle
                 await _session.Publish(new PlayersPriceChanged(priceChanges.ToList()));
 
             if (injuryUpdates.Any())
-                await _mediator.Publish(new InjuryUpdateOccured(injuryUpdates));
+                await _session.Publish(new InjuryUpdateOccured(injuryUpdates));
 
             if (finishedFixtures.Any())
                 await _mediator.Publish(new FixturesFinished(finishedFixtures.ToList()));

--- a/src/FplBot.Core/Extensions/PlayerExtensions.cs
+++ b/src/FplBot.Core/Extensions/PlayerExtensions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Fpl.Client.Models;
+using FplBot.Messaging.Contracts.Events.v1;
 
 namespace FplBot.Core.Extensions
 {
@@ -8,12 +9,12 @@ namespace FplBot.Core.Extensions
     {
         public static bool IsRelevant(this Player player)
         {
-            if (player.OwnershipPercentage > 7)
-            {
-                return true;
-            }
+            return player.OwnershipPercentage > 7;
+        }
 
-            return false;
+        public static bool IsRelevant(this InjuredPlayer player)
+        {
+            return player.OwnershipPercentage > 7;
         }
 
         public static Player Get(this ICollection<Player> players, int? playerId)

--- a/src/FplBot.Core/Handlers/FplEvents/InjuryUpdateHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/InjuryUpdateHandler.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FplBot.Core.Abstractions;
 using FplBot.Core.Extensions;

--- a/src/FplBot.Core/Handlers/FplEvents/InjuryUpdateHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/InjuryUpdateHandler.cs
@@ -4,15 +4,16 @@ using System.Threading.Tasks;
 using FplBot.Core.Abstractions;
 using FplBot.Core.Extensions;
 using FplBot.Core.Helpers;
-using FplBot.Core.Models;
 using FplBot.Data.Abstractions;
 using FplBot.Data.Models;
-using MediatR;
+using FplBot.Messaging.Contracts.Commands.v1;
+using FplBot.Messaging.Contracts.Events.v1;
 using Microsoft.Extensions.Logging;
+using NServiceBus;
 
 namespace FplBot.Core.GameweekLifecycle.Handlers
 {
-    public class InjuryUpdateHandler : INotificationHandler<InjuryUpdateOccured>
+    public class InjuryUpdateHandler : IHandleMessages<InjuryUpdateOccured>
     {
         private readonly ISlackWorkSpacePublisher _publisher;
         private readonly ISlackTeamRepository _slackTeamRepo;
@@ -25,7 +26,7 @@ namespace FplBot.Core.GameweekLifecycle.Handlers
             _logger = logger;
         }
 
-        public async Task Handle(InjuryUpdateOccured notification, CancellationToken cancellationToken)
+        public async Task Handle(InjuryUpdateOccured notification, IMessageHandlerContext context)
         {
             _logger.LogInformation($"Handling player {notification.PlayersWithInjuryUpdates.Count()} status updates");
             var slackTeams = await _slackTeamRepo.GetAllTeams();
@@ -33,11 +34,11 @@ namespace FplBot.Core.GameweekLifecycle.Handlers
             {
                 if (slackTeam.Subscriptions.ContainsSubscriptionFor(EventSubscription.InjuryUpdates))
                 {
-                    var filtered = notification.PlayersWithInjuryUpdates.Where(c => c.ToPlayer.IsRelevant());
+                    var filtered = notification.PlayersWithInjuryUpdates.Where(c => c.Player.IsRelevant());
                     if (filtered.Any())
                     {
                         var formatted = Formatter.FormatInjuryStatusUpdates(filtered);
-                        await _publisher.PublishToWorkspace(slackTeam.TeamId, slackTeam.FplBotSlackChannel, formatted);
+                        await context.SendLocal(new PublishToSlack(slackTeam.TeamId, slackTeam.FplBotSlackChannel, formatted));
                     }
                     else
                     {

--- a/src/FplBot.Core/Helpers/Formatting/Formatter.cs
+++ b/src/FplBot.Core/Helpers/Formatting/Formatter.cs
@@ -359,7 +359,7 @@ namespace FplBot.Core.Helpers
                         chance += $"{chanceOfPlayingChange}%]";
                     }
 
-                    sb.Append($"• {gUpdate.Player.WebName} ({gUpdate.Player.Team.ShortName}). {gUpdate.UpdatedStatus.News} {chance}\n");
+                    sb.Append($"• {gUpdate.Player.WebName} ({gUpdate.Player.Team.ShortName}). {gUpdate.Updated.News} {chance}\n");
                 }
             }
             return sb.ToString();
@@ -367,17 +367,18 @@ namespace FplBot.Core.Helpers
 
         public static string Change(InjuredPlayerUpdate update)
         {
-            return (update.PreviousStatus, update.UpdatedStatus) switch
+            return (PreviousStatus: update.Previous, UpdatedStatus: update.Updated) switch
             {
                 (null, null) => null,
-                ({ News: null}, { News: null}) => null,
-                (_,_) when update.PreviousStatus == update.UpdatedStatus => null,
-                (_,_) => (update.PreviousStatus.Status, update.UpdatedStatus.Status) switch
+                (null,_) => null,
+                (_, null) => null,
+                (_,_) when update.Previous == update.Updated => null,
+                (_,_) => (update.Previous.Status, update.Updated.Status) switch
                 {
                     (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) > 0 => "📈️ Increased chance of playing",
                     (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) < 0 => "📉️ Decreased chance of playing",
                     (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when NewsAdded(update) => "ℹ️ News update",
-                    (_, _) when update.UpdatedStatus.Status.Contains("Self-isolating", StringComparison.InvariantCultureIgnoreCase) => "🦇 COVID-19 🦇",
+                    (_, _) when update.Updated.Status.Contains("Self-isolating", StringComparison.InvariantCultureIgnoreCase) => "🦇 COVID-19 🦇",
                     (_, PlayerStatuses.Injured) => "🤕 Injured",
                     (_, PlayerStatuses.Doubtful) => "⚠️ Doubtful",
                     (_, PlayerStatuses.Suspended) => "❌ Suspended",
@@ -391,17 +392,17 @@ namespace FplBot.Core.Helpers
 
         private static bool NewsAdded(InjuredPlayerUpdate playerStatusUpdate)
         {
-            return playerStatusUpdate.PreviousStatus.News == null && playerStatusUpdate.UpdatedStatus.News != null;
+            return playerStatusUpdate.Previous.News == null && playerStatusUpdate.Updated.News != null;
         }
 
         private const string ChanceOfPlayingPattern = "(\\d+)\\% chance of playing";
 
         private static int? ChanceOfPlayingChange(InjuredPlayerUpdate playerStatusUpdate)
         {
-            if (playerStatusUpdate.PreviousStatus?.News != null && playerStatusUpdate.UpdatedStatus.News != null)
+            if (playerStatusUpdate.Previous?.News != null && playerStatusUpdate.Updated.News != null)
             {
-                var fromChanceMatch = Regex.Matches(playerStatusUpdate.PreviousStatus.News, ChanceOfPlayingPattern, RegexOptions.IgnoreCase);
-                var toChanceMatch = Regex.Matches(playerStatusUpdate.UpdatedStatus.News, ChanceOfPlayingPattern, RegexOptions.IgnoreCase);
+                var fromChanceMatch = Regex.Matches(playerStatusUpdate.Previous.News, ChanceOfPlayingPattern, RegexOptions.IgnoreCase);
+                var toChanceMatch = Regex.Matches(playerStatusUpdate.Updated.News, ChanceOfPlayingPattern, RegexOptions.IgnoreCase);
                 if (fromChanceMatch.Any() && toChanceMatch.Any())
                 {
                     var fromChance = int.Parse(fromChanceMatch.First().Groups[1].Value);

--- a/src/FplBot.Core/Helpers/Formatting/Formatter.cs
+++ b/src/FplBot.Core/Helpers/Formatting/Formatter.cs
@@ -367,30 +367,25 @@ namespace FplBot.Core.Helpers
 
         public static string Change(InjuredPlayerUpdate update)
         {
-            var nullChecks = (prev: update.PreviousStatus, updated: update.UpdatedStatus) switch
+            return (update.PreviousStatus, update.UpdatedStatus) switch
             {
                 (null, null) => null,
                 ({ News: null}, { News: null}) => null,
                 (_,_) when update.PreviousStatus == update.UpdatedStatus => null,
-                (_,_) => "notNull"
-            };
-
-            if (string.IsNullOrEmpty(nullChecks))
-                return null;
-
-            return (PreviousStatus: update.PreviousStatus.Status, UpdatedStatus: update.UpdatedStatus.Status) switch
-            {
-                (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) > 0 => "📈️ Increased chance of playing",
-                (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) < 0 => "📉️ Decreased chance of playing",
-                (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when NewsAdded(update) => "ℹ️ News update",
-                (_, _) s when s.UpdatedStatus.Contains("Self-isolating", StringComparison.InvariantCultureIgnoreCase) => "🦇 COVID-19 🦇",
-                (_, PlayerStatuses.Injured) => "🤕 Injured",
-                (_, PlayerStatuses.Doubtful) => "⚠️ Doubtful",
-                (_, PlayerStatuses.Suspended) => "❌ Suspended",
-                (_, PlayerStatuses.Unavailable) => "👀 Unavailable",
-                (_, PlayerStatuses.NotInSquad) => "😐 Not in squad",
-                (_, PlayerStatuses.Available) => "✅ Available",
-                (_, _) => null
+                (_,_) => (update.PreviousStatus.Status, update.UpdatedStatus.Status) switch
+                {
+                    (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) > 0 => "📈️ Increased chance of playing",
+                    (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) < 0 => "📉️ Decreased chance of playing",
+                    (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when NewsAdded(update) => "ℹ️ News update",
+                    (_, _) when update.UpdatedStatus.Status.Contains("Self-isolating", StringComparison.InvariantCultureIgnoreCase) => "🦇 COVID-19 🦇",
+                    (_, PlayerStatuses.Injured) => "🤕 Injured",
+                    (_, PlayerStatuses.Doubtful) => "⚠️ Doubtful",
+                    (_, PlayerStatuses.Suspended) => "❌ Suspended",
+                    (_, PlayerStatuses.Unavailable) => "👀 Unavailable",
+                    (_, PlayerStatuses.NotInSquad) => "😐 Not in squad",
+                    (_, PlayerStatuses.Available) => "✅ Available",
+                    (_, _) => null
+                }
             };
         }
 

--- a/src/FplBot.Core/Helpers/Formatting/Formatter.cs
+++ b/src/FplBot.Core/Helpers/Formatting/Formatter.cs
@@ -359,7 +359,7 @@ namespace FplBot.Core.Helpers
                         chance += $"{chanceOfPlayingChange}%]";
                     }
 
-                    sb.Append($"• {gUpdate.Player.WebName} ({gUpdate.Team.ShortName}). {gUpdate.UpdatedStatus.News} {chance}\n");
+                    sb.Append($"• {gUpdate.Player.WebName} ({gUpdate.Player.Team.ShortName}). {gUpdate.UpdatedStatus.News} {chance}\n");
                 }
             }
             return sb.ToString();

--- a/src/FplBot.Core/Helpers/Formatting/Formatter.cs
+++ b/src/FplBot.Core/Helpers/Formatting/Formatter.cs
@@ -367,18 +367,18 @@ namespace FplBot.Core.Helpers
 
         public static string Change(InjuredPlayerUpdate update)
         {
-            return (PreviousStatus: update.Previous, UpdatedStatus: update.Updated) switch
+            return (update.Previous, update.Updated) switch
             {
                 (null, null) => null,
                 (null,_) => null,
                 (_, null) => null,
-                (_,_) when update.Previous == update.Updated => null,
+                (_,_) s when s.Previous == s.Updated => null,
                 (_,_) => (update.Previous.Status, update.Updated.Status) switch
                 {
                     (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) > 0 => "📈️ Increased chance of playing",
                     (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) < 0 => "📉️ Decreased chance of playing",
                     (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when NewsAdded(update) => "ℹ️ News update",
-                    (_, _) when update.Updated.Status.Contains("Self-isolating", StringComparison.InvariantCultureIgnoreCase) => "🦇 COVID-19 🦇",
+                    (_, _) when update.Updated.News.Contains("Self-isolating", StringComparison.InvariantCultureIgnoreCase) => "🦇 COVID-19 🦇",
                     (_, PlayerStatuses.Injured) => "🤕 Injured",
                     (_, PlayerStatuses.Doubtful) => "⚠️ Doubtful",
                     (_, PlayerStatuses.Suspended) => "❌ Suspended",
@@ -392,7 +392,7 @@ namespace FplBot.Core.Helpers
 
         private static bool NewsAdded(InjuredPlayerUpdate playerStatusUpdate)
         {
-            return playerStatusUpdate.Previous.News == null && playerStatusUpdate.Updated.News != null;
+            return string.IsNullOrEmpty(playerStatusUpdate.Previous.News) && !string.IsNullOrEmpty(playerStatusUpdate.Updated.News);
         }
 
         private const string ChanceOfPlayingPattern = "(\\d+)\\% chance of playing";

--- a/src/FplBot.Core/Helpers/Formatting/Formatter.cs
+++ b/src/FplBot.Core/Helpers/Formatting/Formatter.cs
@@ -342,7 +342,7 @@ namespace FplBot.Core.Helpers
             return string.Join("\n", list.Select(s => $":black_small_square: {s}"));
         }
 
-        public static string FormatInjuryStatusUpdates(IEnumerable<PlayerUpdate> statusUpdates)
+        public static string FormatInjuryStatusUpdates(IEnumerable<InjuredPlayerUpdate> statusUpdates)
         {
             var grouped = statusUpdates.GroupBy(Change).Where(c => c.Key != null);
             var sb = new StringBuilder();
@@ -359,41 +359,64 @@ namespace FplBot.Core.Helpers
                         chance += $"{chanceOfPlayingChange}%]";
                     }
 
-                    sb.Append($"• {gUpdate.ToPlayer.WebName} ({gUpdate.Team.ShortName}). {gUpdate.ToPlayer.News} {chance}\n");
+                    sb.Append($"• {gUpdate.Player.WebName} ({gUpdate.Team.ShortName}). {gUpdate.UpdatedStatus.News} {chance}\n");
                 }
             }
             return sb.ToString();
         }
 
-        public static string Change(PlayerUpdate update)
+        public static string Change(InjuredPlayerUpdate update)
         {
-            return update switch
+            if (update.PreviousStatus == null)
+                return null;
+            if (update.UpdatedStatus == null)
+                return null;
+
+            if (update.PreviousStatus.News == null && update.UpdatedStatus.News == null)
+                return null;
+
+            if (update.PreviousStatus == update.UpdatedStatus)
+                return null;
+
+            return (PreviousStatus: update.PreviousStatus.Status, UpdatedStatus: update.UpdatedStatus.Status) switch
             {
-                (_, _) s when s.FromPlayer == null && s.ToPlayer == null => null,
-                (_, _) s when s.FromPlayer == null && s.ToPlayer == null => null,
-                (_, _) s when s.FromPlayer.News == null && s.ToPlayer.News == null => null,
-                (PlayerStatuses.Doubtful, PlayerStatuses.Doubtful) s when ChanceOfPlayingChange(s) > 0 => "📈️ Increased chance of playing",
-                (PlayerStatuses.Doubtful, PlayerStatuses.Doubtful) s when ChanceOfPlayingChange(s) < 0 => "📉️ Decreased chance of playing",
-                (PlayerStatuses.Doubtful, PlayerStatuses.Doubtful) s when NewsAdded(s) => "ℹ️ News update",
-                (_, _) s when s.ToPlayer.News.Contains("Self-isolating", StringComparison.InvariantCultureIgnoreCase) => "🦇 COVID-19 🦇",
-                (_, _) s when s.FromPlayer.Status == s.ToPlayer.Status => null,
-                (_, _) s when s.FromPlayer == null => "👋 New player!",
+                (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) > 0 => "📈️ Increased chance of playing",
+                (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when ChanceOfPlayingChange(update) < 0 => "📉️ Decreased chance of playing",
+                (PlayerStatuses.Doubtful,PlayerStatuses.Doubtful) when NewsAdded(update) => "ℹ️ News update",
+                (_, _) s when s.UpdatedStatus.Contains("Self-isolating", StringComparison.InvariantCultureIgnoreCase) => "🦇 COVID-19 🦇",
                 (_, PlayerStatuses.Injured) => "🤕 Injured",
-                (_, PlayerStatuses.Doubtful) => "⚠️ Doubtful️",
+                (_, PlayerStatuses.Doubtful) => "⚠️ Doubtful",
                 (_, PlayerStatuses.Suspended) => "❌ Suspended",
                 (_, PlayerStatuses.Unavailable) => "👀 Unavailable",
                 (_, PlayerStatuses.NotInSquad) => "😐 Not in squad",
                 (_, PlayerStatuses.Available) => "✅ Available",
-                (_, _) => $"⁉️"
+                (_, _) => null
             };
         }
 
-        private static bool NewsAdded(PlayerUpdate playerStatusUpdate)
+        private static bool NewsAdded(InjuredPlayerUpdate playerStatusUpdate)
         {
-            return playerStatusUpdate.FromPlayer.News == null && playerStatusUpdate.ToPlayer.News != null;
+            return playerStatusUpdate.PreviousStatus.News == null && playerStatusUpdate.UpdatedStatus.News != null;
         }
 
         private const string ChanceOfPlayingPattern = "(\\d+)\\% chance of playing";
+
+        private static int? ChanceOfPlayingChange(InjuredPlayerUpdate playerStatusUpdate)
+        {
+            if (playerStatusUpdate.PreviousStatus?.News != null && playerStatusUpdate.UpdatedStatus.News != null)
+            {
+                var fromChanceMatch = Regex.Matches(playerStatusUpdate.PreviousStatus.News, ChanceOfPlayingPattern, RegexOptions.IgnoreCase);
+                var toChanceMatch = Regex.Matches(playerStatusUpdate.UpdatedStatus.News, ChanceOfPlayingPattern, RegexOptions.IgnoreCase);
+                if (fromChanceMatch.Any() && toChanceMatch.Any())
+                {
+                    var fromChance = int.Parse(fromChanceMatch.First().Groups[1].Value);
+                    var toChance = int.Parse(toChanceMatch.First().Groups[1].Value);
+                    return toChance - fromChance;
+                }
+            }
+            return null;
+        }
+
         private static int? ChanceOfPlayingChange(PlayerUpdate playerStatusUpdate)
         {
             if (playerStatusUpdate.FromPlayer?.News != null && playerStatusUpdate.ToPlayer.News != null)

--- a/src/FplBot.Core/Helpers/Formatting/Formatter.cs
+++ b/src/FplBot.Core/Helpers/Formatting/Formatter.cs
@@ -367,15 +367,15 @@ namespace FplBot.Core.Helpers
 
         public static string Change(InjuredPlayerUpdate update)
         {
-            if (update.PreviousStatus == null)
-                return null;
-            if (update.UpdatedStatus == null)
-                return null;
+            var nullChecks = (prev: update.PreviousStatus, updated: update.UpdatedStatus) switch
+            {
+                (null, null) => null,
+                ({ News: null}, { News: null}) => null,
+                (_,_) when update.PreviousStatus == update.UpdatedStatus => null,
+                (_,_) => "notNull"
+            };
 
-            if (update.PreviousStatus.News == null && update.UpdatedStatus.News == null)
-                return null;
-
-            if (update.PreviousStatus == update.UpdatedStatus)
+            if (string.IsNullOrEmpty(nullChecks))
                 return null;
 
             return (PreviousStatus: update.PreviousStatus.Status, UpdatedStatus: update.UpdatedStatus.Status) switch

--- a/src/FplBot.Messaging.Contracts/Events/v1/InjuryUpdateOccured.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/InjuryUpdateOccured.cs
@@ -5,7 +5,7 @@ namespace FplBot.Messaging.Contracts.Events.v1
 {
     public record InjuryUpdateOccured(IEnumerable<InjuredPlayerUpdate> PlayersWithInjuryUpdates) : IEvent;
 
-    public record InjuredPlayerUpdate(InjuredPlayer Player, InjuryStatus PreviousStatus, InjuryStatus UpdatedStatus);
+    public record InjuredPlayerUpdate(InjuredPlayer Player, InjuryStatus Previous, InjuryStatus Updated);
     public record InjuredPlayer(int PlayerId, string WebName, double OwnershipPercentage, TeamDescription Team);
     public record InjuryStatus(string Status, string News);
     public record TeamDescription(long TeamId, string ShortName, string Name);

--- a/src/FplBot.Messaging.Contracts/Events/v1/InjuryUpdateOccured.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/InjuryUpdateOccured.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Events.v1
+{
+    public record InjuryUpdateOccured(IEnumerable<InjuredPlayerUpdate> PlayersWithInjuryUpdates) : IEvent;
+
+    public record InjuredPlayerUpdate(InjuredPlayer Player, InjuryStatus PreviousStatus, InjuryStatus UpdatedStatus, TeamDescription Team);
+    public record InjuredPlayer(int PlayerId, string WebName, double OwnershipPercentage);
+    public record InjuryStatus(string Status, string News);
+    public record TeamDescription(long TeamId, string ShortName, string Name);
+}

--- a/src/FplBot.Messaging.Contracts/Events/v1/InjuryUpdateOccured.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/InjuryUpdateOccured.cs
@@ -5,8 +5,8 @@ namespace FplBot.Messaging.Contracts.Events.v1
 {
     public record InjuryUpdateOccured(IEnumerable<InjuredPlayerUpdate> PlayersWithInjuryUpdates) : IEvent;
 
-    public record InjuredPlayerUpdate(InjuredPlayer Player, InjuryStatus PreviousStatus, InjuryStatus UpdatedStatus, TeamDescription Team);
-    public record InjuredPlayer(int PlayerId, string WebName, double OwnershipPercentage);
+    public record InjuredPlayerUpdate(InjuredPlayer Player, InjuryStatus PreviousStatus, InjuryStatus UpdatedStatus);
+    public record InjuredPlayer(int PlayerId, string WebName, double OwnershipPercentage, TeamDescription Team);
     public record InjuryStatus(string Status, string News);
     public record TeamDescription(long TeamId, string ShortName, string Name);
 }

--- a/src/FplBot.Tests/Formatting/InjuryFormattingTests.cs
+++ b/src/FplBot.Tests/Formatting/InjuryFormattingTests.cs
@@ -124,8 +124,8 @@ namespace FplBot.Tests.Formatting
                     "dontCareNews"
                 ),
                 new InjuryStatus(
-                    "Self-isolating",
-                    "dontCareNews"
+                    "dontCareStatus",
+                    "Self-isolating"
                 )
             ));
 

--- a/src/FplBot.Tests/Formatting/InjuryFormattingTests.cs
+++ b/src/FplBot.Tests/Formatting/InjuryFormattingTests.cs
@@ -22,7 +22,7 @@ namespace FplBot.Tests.Formatting
         {
             var change = Formatter.Change(new InjuredPlayerUpdate(
 
-                new InjuredPlayer(1,"WebName", 13),
+                new InjuredPlayer(1,"WebName", 13, new TeamDescription(1, "TEA", "Team United")),
                 new InjuryStatus(
                     PlayerStatuses.Doubtful,
                     fromNews
@@ -30,8 +30,7 @@ namespace FplBot.Tests.Formatting
                 new InjuryStatus(
                     PlayerStatuses.Doubtful,
                     toNews
-                ),
-                new TeamDescription(1, "TEA", "Team United")
+                )
             ));
             Assert.Contains(expected, change);
         }
@@ -41,7 +40,7 @@ namespace FplBot.Tests.Formatting
         {
             var change = Formatter.Change(new InjuredPlayerUpdate(
 
-                new InjuredPlayer(1,"WebName", 13),
+                new InjuredPlayer(1,"WebName", 13, new TeamDescription(1, "TEA", "Team United")),
                 new InjuryStatus(
                     PlayerStatuses.Doubtful,
                     "some string not containing percentage of playing"
@@ -49,8 +48,7 @@ namespace FplBot.Tests.Formatting
                 new InjuryStatus(
                     PlayerStatuses.Doubtful,
                     "some string not containing percentage of playing"
-                ),
-                new TeamDescription(1, "TEA", "Team United")
+                )
             ));
             Assert.Null(change);
         }
@@ -66,7 +64,7 @@ namespace FplBot.Tests.Formatting
         {
             var change = Formatter.Change(new InjuredPlayerUpdate(
 
-                new InjuredPlayer(1,"WebName", 13),
+                new InjuredPlayer(1,"WebName", 13, new TeamDescription(1, "TEA", "Team United")),
                 new InjuryStatus(
                     fromStatus,
                     "dontcare"
@@ -74,8 +72,7 @@ namespace FplBot.Tests.Formatting
                 new InjuryStatus(
                     toStatus,
                     "dontcare"
-                ),
-                new TeamDescription(1, "TEA", "Team United")
+                )
             ));
             Assert.Contains(expected, change);
         }
@@ -87,7 +84,7 @@ namespace FplBot.Tests.Formatting
         {
             var change = Formatter.Change(new InjuredPlayerUpdate(
 
-                new InjuredPlayer(1,"WebName", 13),
+                new InjuredPlayer(1,"WebName", 13, new TeamDescription(1, "TEA", "Team United")),
                 new InjuryStatus(
                     PlayerStatuses.Doubtful,
                     fromNews
@@ -95,8 +92,7 @@ namespace FplBot.Tests.Formatting
                 new InjuryStatus(
                     PlayerStatuses.Doubtful,
                     toNews
-                ),
-                new TeamDescription(1, "TEA", "Team United")
+                )
             ));
 
             if (expected == null)
@@ -113,7 +109,7 @@ namespace FplBot.Tests.Formatting
         [Fact]
         public void ErronousUpdateHandling()
         {
-            var change = Formatter.Change(new InjuredPlayerUpdate(null, null, null, null));
+            var change = Formatter.Change(new InjuredPlayerUpdate(null, null, null));
             Assert.Null(change);
         }
 
@@ -122,7 +118,7 @@ namespace FplBot.Tests.Formatting
         {
             var change = Formatter.Change(new InjuredPlayerUpdate(
 
-                new InjuredPlayer(1,"WebName", 13),
+                new InjuredPlayer(1,"WebName", 13, new TeamDescription(1, "TEA", "Team United")),
                 new InjuryStatus(
                     "dontCareStatus",
                     "dontCareNews"
@@ -130,8 +126,7 @@ namespace FplBot.Tests.Formatting
                 new InjuryStatus(
                     "Self-isolating",
                     "dontCareNews"
-                ),
-                new TeamDescription(1, "TEA", "Team United")
+                )
             ));
 
             Assert.Contains("🦇", change);
@@ -153,10 +148,9 @@ namespace FplBot.Tests.Formatting
         {
             return new InjuredPlayerUpdate
             (
-                new InjuredPlayer(1, $"Dougie Doubter {from}",13),
+                new InjuredPlayer(1, $"Dougie Doubter {from}",13,new TeamDescription(1,"TEA", "TEAM UTD")),
                 new InjuryStatus(PlayerStatuses.Doubtful,$"Knock - {from}% chance of playing"),
-                new InjuryStatus(PlayerStatuses.Doubtful,$"Knock - {to}% chance of playing"),
-                new TeamDescription(1,"TEA", "TEAM UTD")
+                new InjuryStatus(PlayerStatuses.Doubtful,$"Knock - {to}% chance of playing")
             );
         }
 
@@ -164,10 +158,9 @@ namespace FplBot.Tests.Formatting
         {
             return new InjuredPlayerUpdate
             (
-                new InjuredPlayer(2, $"Able Availbleu",13),
+                new InjuredPlayer(2, $"Able Availbleu",13, new TeamDescription(1,"TEA", "TEAM UTD")),
                 new InjuryStatus(PlayerStatuses.Doubtful,$"Knock - 1337% chance of playing"),
-                new InjuryStatus(PlayerStatuses.Available,""),
-                new TeamDescription(1,"TEA", "TEAM UTD")
+                new InjuryStatus(PlayerStatuses.Available,"")
             );
         }
     }

--- a/src/FplBot.Tests/NearDeadlineTests.cs
+++ b/src/FplBot.Tests/NearDeadlineTests.cs
@@ -136,7 +136,7 @@ namespace FplBot.Tests
 
             await handler.EveryMinuteTick();
 
-            Assert.Equal(1, session.PublishedMessages.Length);
+            Assert.Single(session.PublishedMessages);
             Assert.IsType<TwentyFourHoursToDeadline>(session.PublishedMessages[0].Message);
         }
 
@@ -156,7 +156,7 @@ namespace FplBot.Tests
 
             await handler.EveryMinuteTick();
 
-            Assert.Equal(1, session.PublishedMessages.Length);
+            Assert.Single(session.PublishedMessages);
             Assert.IsType<TwentyFourHoursToDeadline>(session.PublishedMessages[0].Message);
         }
     }

--- a/src/FplBot.Tests/StateTests.cs
+++ b/src/FplBot.Tests/StateTests.cs
@@ -56,7 +56,8 @@ namespace FplBot.Tests
             var state = CreateNewInjuryScenario();
             await state.Reset(1);
             await state.Refresh(1);
-            A.CallTo(() => _Mediator.Publish(A<InjuryUpdateOccured>._, CancellationToken.None)).MustHaveHappenedOnceExactly();
+            Assert.Single(_MessageSession.PublishedMessages);
+            Assert.IsType<InjuryUpdateOccured>(_MessageSession.PublishedMessages[0].Message);
         }
 
         [Fact]
@@ -76,7 +77,8 @@ namespace FplBot.Tests
             var state = CreateChangeInDoubtfulnessScenario();
             await state.Reset(1);
             await state.Refresh(1);
-            A.CallTo(() => _Mediator.Publish(A<InjuryUpdateOccured>._, CancellationToken.None)).MustHaveHappenedOnceExactly();
+            Assert.Single(_MessageSession.PublishedMessages);
+            Assert.IsType<InjuryUpdateOccured>(_MessageSession.PublishedMessages[0].Message);
         }
 
         [Fact]
@@ -86,6 +88,7 @@ namespace FplBot.Tests
             await state.Reset(1);
             await state.Refresh(1);
             A.CallTo(() => _Mediator.Publish(null, CancellationToken.None)).WithAnyArguments().MustNotHaveHappened();
+            Assert.Empty(_MessageSession.PublishedMessages);
         }
 
         [Fact]

--- a/src/FplBot.Tests/StateTests.cs
+++ b/src/FplBot.Tests/StateTests.cs
@@ -10,9 +10,9 @@ using FplBot.Data.Abstractions;
 using FplBot.Data.Models;
 using FplBot.Messaging.Contracts.Events.v1;
 using MediatR;
-using NServiceBus;
 using NServiceBus.Testing;
 using Xunit;
+
 
 namespace FplBot.Tests
 {

--- a/src/FplBot.WebApi/Program.cs
+++ b/src/FplBot.WebApi/Program.cs
@@ -16,7 +16,8 @@ namespace FplBot.WebApi
         {
             Console.WriteLine(Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version);
             Console.WriteLine(Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyVersionAttribute>()?.Version);
-            Console.WriteLine(Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion); CreateHostBuilder(args).Build().Run();
+            Console.WriteLine(Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
+            CreateHostBuilder(args).Build().Run();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>


### PR DESCRIPTION
🚃 Migrates injury update notifications from in-mem MediatR messaging onto Azure ServiceBus
🦠 Removes XUnit build warnings