### PR TITLE
Moves GameweekJustStarted messaging from in-mem MediatR to ASB

### DIFF
--- a/src/Fpl.Client/Models/StatType.cs
+++ b/src/Fpl.Client/Models/StatType.cs
@@ -1,4 +1,4 @@
-﻿namespace FplBot.Core.Models
+namespace Fpl.Client.Models
 {
     public enum StatType
     {

--- a/src/Fpl.Workers/Events/InternalEvents.cs
+++ b/src/Fpl.Workers/Events/InternalEvents.cs
@@ -2,9 +2,10 @@ using Fpl.Client.Models;
 using MediatR;
 
 namespace FplBot.Core.Models
-{    
+{
     // Only used for internal state in Workers
     internal record GameweekMonitoringStarted(Gameweek CurrentGameweek) : INotification;
     internal record GameweekCurrentlyOnGoing(Gameweek Gameweek) : INotification;
     internal record GameweekCurrentlyFinished(Gameweek Gameweek) : INotification;
+    internal record GameweekJustBegan(Gameweek Gameweek) : INotification;
 }

--- a/src/Fpl.Workers/Events/PublicEvents.cs
+++ b/src/Fpl.Workers/Events/PublicEvents.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace FplBot.Core.Models
 {
     // Public events using in-mem MediatR handling:
-    public record GameweekJustBegan(Gameweek Gameweek) : INotification;
+
     public record FixtureEventsOccured(FixtureUpdates FixtureEvents) : INotification;
     public record FixturesFinished(IEnumerable<FinishedFixture> FinishedFixture) : INotification;
     public record GameweekFinished(Gameweek Gameweek) : INotification;

--- a/src/Fpl.Workers/Extensions/EnumerableExtensions.cs
+++ b/src/Fpl.Workers/Extensions/EnumerableExtensions.cs
@@ -7,18 +7,6 @@ namespace FplBot.Core.Extensions
 {
     public static class EnumerableExtensions
     {
-        public static async Task ForEach<T>(this IEnumerable<T> enumerable, Func<T, Task> func)
-        {
-            foreach (var item in enumerable.MaterializeToArray())
-            {
-                await func(item);
-            }
-        }
-
-        public static IEnumerable<T> OrEmptyIfNull<T>(this IEnumerable<T> enumerable)
-        {
-            return enumerable ?? Enumerable.Empty<T>();
-        }
 
         public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T> enumerable)
         {
@@ -47,28 +35,6 @@ namespace FplBot.Core.Extensions
             return array[random.Next(0, array.Length)];
         }
 
-        public static string Join(
-            this IEnumerable<string> enumerable, 
-            string separator = ", ",
-            string lastSeparator = " and ")
-        {
-            if (enumerable == null)
-            {
-                return string.Empty;
-            }
 
-            var array = enumerable.MaterializeToArray();
-
-            if (!array.Any())
-            {
-                return string.Empty;
-            }
-            if (array.Length == 1)
-            {
-                return array.Single();
-            }
-
-            return string.Join(separator, array.Take(array.Length - 1)) + lastSeparator + array.Last();
-        }
     }
 }

--- a/src/Fpl.Workers/Models/FixtureEvents.cs
+++ b/src/Fpl.Workers/Models/FixtureEvents.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Fpl.Client.Models;
 
 namespace FplBot.Core.Models
 {

--- a/src/FplBot.Core/Extensions/StatTypeMethods.cs
+++ b/src/FplBot.Core/Extensions/StatTypeMethods.cs
@@ -1,3 +1,4 @@
+using Fpl.Client.Models;
 using FplBot.Data.Models;
 
 namespace FplBot.Core.Models

--- a/src/FplBot.Core/Handlers/FplEvents/GameweekJustBeganUpdateStatsHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/GameweekJustBeganUpdateStatsHandler.cs
@@ -1,24 +1,28 @@
-using System.Threading;
 using System.Threading.Tasks;
 using FplBot.Core.Handlers.InternalCommands;
-using FplBot.Core.Models;
+using FplBot.Messaging.Contracts.Events.v1;
 using MediatR;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
 
 namespace FplBot.Core.Handlers.FplEvents
 {
-    internal class GameweekEndedUpdateStatsHandler : INotificationHandler<GameweekJustBegan>
+    internal class GameweekJustBeganUpdateStatsHandler : IHandleMessages<GameweekJustBegan>
     {
         private readonly IMediator _mediator;
-        
-        public GameweekEndedUpdateStatsHandler(IMediator mediator)
+        private readonly ILogger<GameweekJustBeganUpdateStatsHandler> _logger;
+
+        public GameweekJustBeganUpdateStatsHandler(IMediator mediator, ILogger<GameweekJustBeganUpdateStatsHandler> logger)
         {
             _mediator = mediator;
+            _logger = logger;
         }
 
-        public async Task Handle(GameweekJustBegan notification, CancellationToken cancellationToken)
+        public async Task Handle(GameweekJustBegan notification, IMessageHandlerContext context)
         {
-            var t1 = _mediator.Publish(new UpdateAllEntryStats(), cancellationToken);
-            var t2 = _mediator.Publish(new UpdateSelfishStats(Gameweek : notification.Gameweek.Id), cancellationToken);
+            _logger.LogInformation($"Handling using {nameof(GameweekJustBeganUpdateStatsHandler)}");
+            var t1 = _mediator.Publish(new UpdateAllEntryStats());
+            var t2 = _mediator.Publish(new UpdateSelfishStats(Gameweek : notification.NewGameweek.Id));
             await Task.WhenAll(t1, t2);
         }
     }

--- a/src/FplBot.Core/Handlers/FplEvents/GameweekStartedHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/GameweekStartedHandler.cs
@@ -1,18 +1,17 @@
-using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using FplBot.Core.Abstractions;
 using FplBot.Core.Extensions;
-using FplBot.Core.Models;
 using FplBot.Data.Abstractions;
 using FplBot.Data.Models;
-using MediatR;
+using FplBot.Messaging.Contracts.Commands.v1;
+using FplBot.Messaging.Contracts.Events.v1;
 using Microsoft.Extensions.Logging;
+using NServiceBus;
 
 namespace FplBot.Core.GameweekLifecycle.Handlers
 {
-    internal class GameweekStartedHandler : INotificationHandler<GameweekJustBegan>
+    internal class GameweekStartedHandler : IHandleMessages<GameweekJustBegan>, IHandleMessages<ProcessGameweekStartedForSlackWorkspace>
     {
         private readonly ICaptainsByGameWeek _captainsByGameweek;
         private readonly ITransfersByGameWeek _transfersByGameweek;
@@ -33,46 +32,45 @@ namespace FplBot.Core.GameweekLifecycle.Handlers
             _logger = logger;
         }
 
-        public async Task Handle(GameweekJustBegan notification, CancellationToken cancellationToken)
+        public async Task Handle(GameweekJustBegan notification, IMessageHandlerContext context)
         {
-            var newGameweek = notification.Gameweek.Id;
-            await _publisher.PublishToAllWorkspaceChannels($"Gameweek {newGameweek}!");
             var teams = await _teamRepo.GetAllTeams();
-
             foreach (var team in teams)
             {
-                try
-                {
-                    var messages = new List<string>();
-
-                    if (team.Subscriptions.ContainsSubscriptionFor(EventSubscription.Captains))
-                    {
-                        messages.Add(await _captainsByGameweek.GetCaptainsByGameWeek(newGameweek, (int)team.FplbotLeagueId));
-                        messages.Add(await _captainsByGameweek.GetCaptainsChartByGameWeek(newGameweek, (int)team.FplbotLeagueId));
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Team {team} hasn't subscribed for gw start captains, so bypassing it", team.TeamId);
-                    }
-
-                    if (team.Subscriptions.ContainsSubscriptionFor(EventSubscription.Transfers))
-                    {
-                        messages.Add(await _transfersByGameweek.GetTransfersByGameweekTexts(newGameweek, (int)team.FplbotLeagueId));
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Team {team} hasn't subscribed for gw start transfers, so bypassing it", team.TeamId);
-                    }
-
-                    await _publisher.PublishToWorkspace(team.TeamId, team.FplBotSlackChannel, messages.ToArray());
-
-                }
-                catch (Exception e)
-                {
-                    _logger.LogError(e, e.Message);
-                }
-
+                await context.SendLocal(new ProcessGameweekStartedForSlackWorkspace(team.TeamId, notification.NewGameweek.Id));
             }
+        }
+
+        public async Task Handle(ProcessGameweekStartedForSlackWorkspace message, IMessageHandlerContext context)
+        {
+            var newGameweek = message.GameweekId;
+
+            var team = await _teamRepo.GetTeam(message.WorkspaceId);
+            if(team.Subscriptions.ContainsSubscriptionFor(EventSubscription.Captains) || team.Subscriptions.ContainsSubscriptionFor(EventSubscription.Transfers))
+                await _publisher.PublishToWorkspace($"Gameweek {message.GameweekId}!");
+
+            var messages = new List<string>();
+
+            if (team.Subscriptions.ContainsSubscriptionFor(EventSubscription.Captains))
+            {
+                messages.Add(await _captainsByGameweek.GetCaptainsByGameWeek(newGameweek, (int)team.FplbotLeagueId));
+                messages.Add(await _captainsByGameweek.GetCaptainsChartByGameWeek(newGameweek, (int)team.FplbotLeagueId));
+            }
+            else
+            {
+                _logger.LogInformation("Team {team} hasn't subscribed for gw start captains, so bypassing it", team.TeamId);
+            }
+
+            if (team.Subscriptions.ContainsSubscriptionFor(EventSubscription.Transfers))
+            {
+                messages.Add(await _transfersByGameweek.GetTransfersByGameweekTexts(newGameweek, (int)team.FplbotLeagueId));
+            }
+            else
+            {
+                _logger.LogInformation("Team {team} hasn't subscribed for gw start transfers, so bypassing it", team.TeamId);
+            }
+
+            await _publisher.PublishToWorkspace(team.TeamId, team.FplBotSlackChannel, messages.ToArray());
         }
     }
 }

--- a/src/FplBot.Core/Handlers/InternalCommands/UpdateEntryStatsCommandHandler.cs
+++ b/src/FplBot.Core/Handlers/InternalCommands/UpdateEntryStatsCommandHandler.cs
@@ -8,6 +8,7 @@ using FplBot.Core.Extensions;
 using FplBot.Data.Abstractions;
 using FplBot.Data.Models;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace FplBot.Core.Handlers.InternalCommands
 {
@@ -19,18 +20,21 @@ namespace FplBot.Core.Handlers.InternalCommands
         private readonly IEntryHistoryClient _entryHistoryClient;
         private readonly IGlobalSettingsClient _settingsClient;
         private readonly IVerifiedEntriesRepository _verifiedEntriesRepository;
+        private readonly ILogger<UpdateEntryStatsCommandHandler> _logger;
         private readonly IEntryClient _entryClient;
 
-        public UpdateEntryStatsCommandHandler(IEntryHistoryClient entryHistoryClient, IGlobalSettingsClient settingsClient, IEntryClient entryClient, IVerifiedEntriesRepository verifiedEntriesRepository)
+        public UpdateEntryStatsCommandHandler(IEntryHistoryClient entryHistoryClient, IGlobalSettingsClient settingsClient, IEntryClient entryClient, IVerifiedEntriesRepository verifiedEntriesRepository, ILogger<UpdateEntryStatsCommandHandler> logger)
         {
             _entryHistoryClient = entryHistoryClient;
             _settingsClient = settingsClient;
             _verifiedEntriesRepository = verifiedEntriesRepository;
+            _logger = logger;
             _entryClient = entryClient;
         }
 
         public async Task Handle(UpdateAllEntryStats notification, CancellationToken cancellationToken)
         {
+            _logger.LogInformation($"Handling UpdateAllEntryStats");
             var allEntries = await _verifiedEntriesRepository.GetAllVerifiedEntries();
             var settings = await _settingsClient.GetGlobalSettings();
             var players = settings.Players;
@@ -43,6 +47,7 @@ namespace FplBot.Core.Handlers.InternalCommands
 
         public async Task Handle(UpdateEntryStats notification, CancellationToken cancellationToken)
         {
+            _logger.LogInformation($"Handling UpdateEntryStats");
             var settings = await _settingsClient.GetGlobalSettings();
             var players = settings.Players;
             var newStats = await GetUpdatedStatsForEntry(notification.EntryId, players);

--- a/src/FplBot.Core/Helpers/EnumerableExtensions.cs
+++ b/src/FplBot.Core/Helpers/EnumerableExtensions.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace FplBot.Core.Helpers
+{
+    public static class EnumarableExtensions
+    {
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T> enumerable)
+        {
+            return enumerable.Where(x => x != null);
+        }
+
+        public static async Task ForEach<T>(this IEnumerable<T> enumerable, Func<T, Task> func)
+        {
+            foreach (var item in enumerable.MaterializeToArray())
+            {
+                await func(item);
+            }
+        }
+
+        public static T[] MaterializeToArray<T>(this IEnumerable<T> enumerable)
+        {
+            return enumerable as T[] ?? enumerable.ToArray();
+        }
+
+        public static string Join(
+            this IEnumerable<string> enumerable,
+            string separator = ", ",
+            string lastSeparator = " and ")
+        {
+            if (enumerable == null)
+            {
+                return string.Empty;
+            }
+
+            var array = enumerable.MaterializeToArray();
+
+            if (!array.Any())
+            {
+                return string.Empty;
+            }
+            if (array.Length == 1)
+            {
+                return array.Single();
+            }
+
+            return string.Join(separator, array.Take(array.Length - 1)) + lastSeparator + array.Last();
+        }
+    }
+}

--- a/src/FplBot.Core/ServiceCollectionExtensions.cs
+++ b/src/FplBot.Core/ServiceCollectionExtensions.cs
@@ -35,9 +35,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ILeagueEntriesByGameweek, LeagueEntriesByGameweek>();
             services.AddSingleton<IGameweekHelper, GameweekHelper>();
             services.AddSingleton<ISlackWorkSpacePublisher,SlackWorkSpacePublisher>();
-
-            services.AddMediatR(typeof(FplEventHandlers));
-            services.AddFplWorkers();
             return services;
         }
 

--- a/src/FplBot.Messaging.Contracts/Commands/v1/ProcessGameweekStartedForSlackWorkspace.cs
+++ b/src/FplBot.Messaging.Contracts/Commands/v1/ProcessGameweekStartedForSlackWorkspace.cs
@@ -1,0 +1,6 @@
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Commands.v1
+{
+    public record ProcessGameweekStartedForSlackWorkspace(string WorkspaceId, int GameweekId) : ICommand;
+}

--- a/src/FplBot.Messaging.Contracts/Events/v1/GameweekJustBegan.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/GameweekJustBegan.cs
@@ -1,0 +1,8 @@
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Events.v1
+{
+    public record GameweekJustBegan(NewGameweek NewGameweek) : IEvent;
+
+    public record NewGameweek(int Id);
+}

--- a/src/FplBot.Tests/Helpers/Factory.cs
+++ b/src/FplBot.Tests/Helpers/Factory.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FplBot.Core.Abstractions;
 using FplBot.Data.Abstractions;
+using MediatR;
 using Nest;
 using Newtonsoft.Json;
 using NServiceBus;
@@ -67,6 +68,7 @@ namespace FplBot.Tests.Helpers
             services.Replace<IElasticClient>(elasticClient);
             services.AddSingleton<ILogger<CookieFetcher>, XUnitTestOutputLogger<CookieFetcher>>(s => new XUnitTestOutputLogger<CookieFetcher>(logger));
             services.AddSingleton<IMessageSession>(A.Fake<IMessageSession>()); // Faking NServicebus
+            services.AddFplWorkers();
             var provider = services.BuildServiceProvider();
             return provider;
         }

--- a/src/FplBot.WebApi/FplBot.WebApi.csproj
+++ b/src/FplBot.WebApi/FplBot.WebApi.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FplBot.Core\FplBot.Core.csproj" />
+    <ProjectReference Include="..\Fpl.Workers\Fpl.Workers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/FplBot.WebApi/Startup.cs
+++ b/src/FplBot.WebApi/Startup.cs
@@ -47,6 +47,8 @@ namespace FplBot.WebApi
             services.Configure<AnalyticsOptions>(Configuration);
             services.AddReducedHttpClientFactoryLogging();
             services.AddFplBot(Configuration).AddFplBotSlackEventHandlers();
+            services.AddFplWorkers();
+            services.AddMediatR(typeof(FplEventHandlers));
             services.AddMediatR(typeof(Startup));
             services.AddAuthentication(options =>
                 {


### PR DESCRIPTION
- Puts captains&transfers messaging triggered by `GameweekJustsBegan` event onto the  🚌  
- Small move towards making fpl worker and slackbot less coupled