### PR TITLE
Removes coupling between event emitter and event handlers

### DIFF
--- a/src/Fpl.Workers/Extensions/EnumerableExtensions.cs
+++ b/src/Fpl.Workers/Extensions/EnumerableExtensions.cs
@@ -17,24 +17,5 @@ namespace FplBot.Core.Extensions
         {
             return enumerable as T[] ?? enumerable.ToArray();
         }
-
-        public static T GetRandom<T>(this IEnumerable<T> enumerable)
-        {
-            var array = enumerable.MaterializeToArray();
-            if (!array.Any())
-            {
-                return default;
-            }
-
-            if (array.Length == 1)
-            {
-                return array.Single();
-            }
-
-            var random = new Random();
-            return array[random.Next(0, array.Length)];
-        }
-
-
     }
 }

--- a/src/Fpl.Workers/Models/FinishedFixture.cs
+++ b/src/Fpl.Workers/Models/FinishedFixture.cs
@@ -3,18 +3,5 @@ using Fpl.Client.Models;
 
 namespace FplBot.Core.Models
 {
-    public class FinishedFixture
-    {
-        public Fixture Fixture { get; set; }
-        public Team HomeTeam { get; set; }
-        public Team AwayTeam { get; set; }
 
-        public IEnumerable<BonusPointsPlayer> BonusPoints { get; set; } = new List<BonusPointsPlayer>();
-    }
-
-    public class BonusPointsPlayer
-    {
-        public Player Player { get; set; }
-        public int BonusPoints { get; set; }
-    }
 }

--- a/src/Fpl.Workers/Models/Mappers/LiveEventsExtractor.cs
+++ b/src/Fpl.Workers/Models/Mappers/LiveEventsExtractor.cs
@@ -48,58 +48,20 @@ namespace FplBot.Core.Helpers
             }).WhereNotNull();
         }
 
-        public static IEnumerable<FinishedFixture> GetProvisionalFinishedFixtures(ICollection<Fixture> latestFixtures, ICollection<Fixture> current, ICollection<Team> teams, ICollection<Player> players)
+        public static IEnumerable<int> GetProvisionalFinishedFixtures(ICollection<Fixture> latestFixtures, ICollection<Fixture> current, ICollection<Team> teams, ICollection<Player> players)
         {
             if(latestFixtures == null)
-                return new List<FinishedFixture>();
+                return new List<int>();
 
             if (current == null)
-                return new List<FinishedFixture>();
+                return new List<int>();
 
             var latestFinished = latestFixtures.Where(f => f.FinishedProvisional);
             var currentFinished = current.Where(f => f.FinishedProvisional);
             var newFinished = latestFinished.Except(currentFinished, new FixtureComparer());
             if (newFinished.Any())
-                return newFinished.Select(n => CreateFinishedFixture(teams, players, n));
-            return new List<FinishedFixture>();
-        }
-
-        public static FinishedFixture CreateFinishedFixture(ICollection<Team> teams, ICollection<Player> players, Fixture n)
-        {
-            return new FinishedFixture
-            {
-                Fixture = n,
-                HomeTeam = teams.First(t => t.Id == n.HomeTeamId),
-                AwayTeam = teams.First(t => t.Id == n.AwayTeamId),
-                BonusPoints = CreateBonusPlayers(players, n)
-            };
-        }
-
-        public static IEnumerable<BonusPointsPlayer> CreateBonusPlayers(ICollection<Player> players, Fixture fixture)
-        {
-            try
-            {
-                var bonusPointsHome = fixture.Stats.FirstOrDefault(s => s.Identifier == "bps")?.HomeStats;
-                var bonusPointsAway = fixture.Stats.FirstOrDefault(s => s.Identifier == "bps")?.AwayStats;
-
-                var home = bonusPointsHome.Select(BpsFilter).ToList();
-                var away = bonusPointsAway.Select(BpsFilter).ToList();
-                var aggregated = home.Concat(away).OrderByDescending(bpp => bpp.BonusPoints);
-                return aggregated;
-
-                BonusPointsPlayer BpsFilter(FixtureStatValue bps)
-                {
-                    return new BonusPointsPlayer
-                    {
-                        Player = players.First(p => p.Id == bps.Element),
-                        BonusPoints = bps.Value
-                    };
-                }
-            }
-            catch
-            {
-                return new List<BonusPointsPlayer>();
-            }
+                return newFinished.Select(n => n.Id);
+            return new List<int>();
         }
     }
 

--- a/src/Fpl.Workers/States/State.cs
+++ b/src/Fpl.Workers/States/State.cs
@@ -69,7 +69,7 @@ namespace FplBot.Core.GameweekLifecycle
 
             foreach (var fixture in finishedFixtures)
             {
-                await _session.Publish(new FixtureFinished(fixture.Fixture.Id));
+                await _session.Publish(new FixtureFinished(fixture));
             }
 
             if (newPlayers.Any())

--- a/src/FplBot.Core/FplBot.Core.csproj
+++ b/src/FplBot.Core/FplBot.Core.csproj
@@ -17,7 +17,6 @@
     <ProjectReference Include="..\Fpl.Client\Fpl.Client.csproj" />
     <ProjectReference Include="..\ext\Slackbot.Net.SlackClients.Http\Slackbot.Net.SlackClients.Http.csproj" />
     <ProjectReference Include="..\ext\Slackbot.Net.Endpoints\Slackbot.Net.Endpoints.csproj" />
-    <ProjectReference Include="..\Fpl.Workers\Fpl.Workers.csproj" />
     <ProjectReference Include="..\FplBot.Data\FplBot.Data.csproj" />
     <ProjectReference Include="..\FplBot.Messaging.Contracts\FplBot.Messaging.Contracts.csproj" />     
     <ProjectReference Include="..\Fpl.Search\Fpl.Search.csproj" />

--- a/src/FplBot.Core/Handlers/FplEvents/FixtureFulltimeHandler.cs
+++ b/src/FplBot.Core/Handlers/FplEvents/FixtureFulltimeHandler.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Fpl.Client.Abstractions;
+using Fpl.Client.Models;
 using FplBot.Core.Extensions;
 using FplBot.Core.Helpers;
 using FplBot.Data.Abstractions;
@@ -38,7 +40,7 @@ namespace FplBot.Core.GameweekLifecycle.Handlers
             var settings = await _settingsClient.GetGlobalSettings();
             var fixtures = await _fixtureClient.GetFixtures();
             var fplfixture = fixtures.FirstOrDefault(f => f.Id == message.FixtureId);
-            var fixture = LiveEventsExtractor.CreateFinishedFixture(settings.Teams, settings.Players, fplfixture);
+            var fixture = CreateFinishedFixture(settings.Teams, settings.Players, fplfixture);
             var title = $"*FT: {fixture.HomeTeam.ShortName} {fixture.Fixture.HomeTeamScore}-{fixture.Fixture.AwayTeamScore} {fixture.AwayTeam.ShortName}*";
             var threadMessage = Formatter.FormatProvisionalFinished(fixture);
 
@@ -48,6 +50,44 @@ namespace FplBot.Core.GameweekLifecycle.Handlers
                 {
                     await context.SendLocal(new PublishFulltimeMessageToSlackWorkspace(slackTeam.TeamId, title, threadMessage));
                 }
+            }
+        }
+
+        private static FinishedFixture CreateFinishedFixture(ICollection<Team> teams, ICollection<Player> players, Fixture n)
+        {
+            return new FinishedFixture
+            {
+                Fixture = n,
+                HomeTeam = teams.First(t => t.Id == n.HomeTeamId),
+                AwayTeam = teams.First(t => t.Id == n.AwayTeamId),
+                BonusPoints = CreateBonusPlayers(players, n)
+            };
+        }
+
+        private static IEnumerable<BonusPointsPlayer> CreateBonusPlayers(ICollection<Player> players, Fixture fixture)
+        {
+            try
+            {
+                var bonusPointsHome = fixture.Stats.FirstOrDefault(s => s.Identifier == "bps")?.HomeStats;
+                var bonusPointsAway = fixture.Stats.FirstOrDefault(s => s.Identifier == "bps")?.AwayStats;
+
+                var home = bonusPointsHome.Select(BpsFilter).ToList();
+                var away = bonusPointsAway.Select(BpsFilter).ToList();
+                var aggregated = home.Concat(away).OrderByDescending(bpp => bpp.BonusPoints);
+                return aggregated;
+
+                BonusPointsPlayer BpsFilter(FixtureStatValue bps)
+                {
+                    return new BonusPointsPlayer
+                    {
+                        Player = players.First(p => p.Id == bps.Element),
+                        BonusPoints = bps.Value
+                    };
+                }
+            }
+            catch
+            {
+                return new List<BonusPointsPlayer>();
             }
         }
 
@@ -64,5 +104,20 @@ namespace FplBot.Core.GameweekLifecycle.Handlers
                 });
             }
         }
+    }
+
+    public class FinishedFixture
+    {
+        public Fixture Fixture { get; set; }
+        public Team HomeTeam { get; set; }
+        public Team AwayTeam { get; set; }
+
+        public IEnumerable<BonusPointsPlayer> BonusPoints { get; set; } = new List<BonusPointsPlayer>();
+    }
+
+    public class BonusPointsPlayer
+    {
+        public Player Player { get; set; }
+        public int BonusPoints { get; set; }
     }
 }

--- a/src/FplBot.Core/Handlers/SlackEvents/UnknownAppMentionCommandHandler.cs
+++ b/src/FplBot.Core/Handlers/SlackEvents/UnknownAppMentionCommandHandler.cs
@@ -55,9 +55,9 @@ namespace FplBot.Core.Handlers.SlackEvents
                 //     fixture.Stats.First(s => s.Identifier == "goals_scored").HomeStats = newl.ToList();
                 // }
             }
-
-            var allFixtureEvents = LiveEventsExtractor.GetUpdatedFixtureEvents(updated,previous, settings.Players, settings.Teams);
-            await _session.Publish(new FixtureEventsOccured(allFixtureEvents.ToArray()[0..1].ToList()));
+            //
+            // var allFixtureEvents = LiveEventsExtractor.GetUpdatedFixtureEvents(updated,previous, settings.Players, settings.Teams);
+            // await _session.Publish(new FixtureEventsOccured(allFixtureEvents.ToArray()[0..1].ToList()));
         }
     }
 }

--- a/src/FplBot.Core/Helpers/ChipsPlayed.cs
+++ b/src/FplBot.Core/Helpers/ChipsPlayed.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Fpl.Client;
 using Fpl.Client.Abstractions;
-using Fpl.Workers;
 using FplBot.Core.Abstractions;
 
 namespace FplBot.Core.Helpers

--- a/src/FplBot.Core/Helpers/EnumerableExtensions.cs
+++ b/src/FplBot.Core/Helpers/EnumerableExtensions.cs
@@ -7,10 +7,10 @@ namespace FplBot.Core.Helpers
 {
     public static class EnumarableExtensions
     {
-        // public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T> enumerable)
-        // {
-        //     return enumerable.Where(x => x != null);
-        // }
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T> enumerable)
+        {
+            return enumerable.Where(x => x != null);
+        }
 
         public static async Task ForEach<T>(this IEnumerable<T> enumerable, Func<T, Task> func)
         {
@@ -47,6 +47,23 @@ namespace FplBot.Core.Helpers
             }
 
             return string.Join(separator, array.Take(array.Length - 1)) + lastSeparator + array.Last();
+        }
+
+        public static T GetRandom<T>(this IEnumerable<T> enumerable)
+        {
+            var array = enumerable.MaterializeToArray();
+            if (!array.Any())
+            {
+                return default;
+            }
+
+            if (array.Length == 1)
+            {
+                return array.Single();
+            }
+
+            var random = new Random();
+            return array[random.Next(0, array.Length)];
         }
     }
 }

--- a/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
+++ b/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
@@ -1,4 +1,5 @@
 using Fpl.Client.Models;
+using FplBot.Core.GameweekLifecycle.Handlers;
 using FplBot.Core.Helpers;
 using FplBot.Core.Models;
 using Xunit;
@@ -14,7 +15,7 @@ namespace FplBot.Tests.Formatting
         {
             _helper = helper;
         }
-        
+
         [Fact]
         public void Distributed()
         {
@@ -27,7 +28,7 @@ namespace FplBot.Tests.Formatting
                 BonusPointsPlayer("player-A", 50)
             })));
         }
-        
+
         [Fact]
         public void SharedFirstPlace()
         {
@@ -40,7 +41,7 @@ namespace FplBot.Tests.Formatting
                 BonusPointsPlayer("player-A", 40)
             })));
         }
-        
+
         [Fact]
         public void AllSharedFirstPlace()
         {
@@ -53,7 +54,7 @@ namespace FplBot.Tests.Formatting
                 BonusPointsPlayer("player-A", 40)
             })));
         }
-        
+
         [Fact]
         public void TiedSecondPlace()
         {
@@ -66,7 +67,7 @@ namespace FplBot.Tests.Formatting
                 BonusPointsPlayer("player-A", 40)
             })));
         }
-        
+
         [Fact]
         public void TiedSecondPlaceForThreePlayers()
         {
@@ -79,7 +80,7 @@ namespace FplBot.Tests.Formatting
                 BonusPointsPlayer("player-A", 40)
             })));
         }
-        
+
         [Fact]
         public void TiedThirdPlace()
         {
@@ -92,7 +93,7 @@ namespace FplBot.Tests.Formatting
                 BonusPointsPlayer("player-A", 40)
             })));
         }
-        
+
         [Fact]
         public void TiedThirdPlaceForMultiplePlayers()
         {

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -45,6 +45,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\FplBot.Core\FplBot.Core.csproj" />
+      <ProjectReference Include="..\Fpl.Workers\Fpl.Workers.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removes coupling to Fpl.Worker in Slackbot (`FplBot.Core`):

https://github.com/fplbot/fplbot/blob/1343da0ddb0300eaf22bac3909ebfa7ac2569274/src/FplBot.Core/FplBot.Core.csproj#L20

The FPL event emitter a.k.a. `Fpl.Worker` and the Slackbot (a.k.a. `FplBot.Core`) are now entirely independent of each other allowing for scaling handlers different to emitters. The workers and the handlers are still kept hosted in the same host until we see a need to scale up handlers.