### PR TITLE
Use GitHub API for release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Exciting New Features 🎉
+      labels:
+        - feature
+        - enhancement
+    - title: Rework 💪
+      labels:
+        - chore
+        - refactoring
+    - title: Bugfixes 🐛
+      labels:
+        - bug
+        - bugfix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -68,12 +68,16 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_TOKEN }}
         run: heroku container:release web --app blank-fplbot
       - run: git log $(git describe --tags --abbrev=0)..HEAD --oneline
-      - name: Log commit messages since last release
+      - name: Generate CHANGELOG.md
         id: releasenotes
         run: |
-          echo 'RELEASE_NOTES<<EOF' >> $GITHUB_ENV
-          git log $(git describe --tags --abbrev=0)..HEAD --oneline >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
+          -f tag_name="${{ steps.gitversion.outputs.majorMinorPatch }}" \
+          -q .body > CHANGELOG.md
+          echo -e "\n\n" >> CHANGELOG.md
+          git log $(git describe --tags --abbrev=0)..HEAD --oneline >> CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -82,7 +86,7 @@ jobs:
         with:
           tag_name: ${{ steps.gitversion.outputs.majorMinorPatch }}
           release_name: Release ${{ steps.gitversion.outputs.majorMinorPatch }}
-          body: ${{ env.RELEASE_NOTES }}
+          body_path: CHANGELOG.md
           draft: false
           prerelease: false
       - name: update deployment status


### PR DESCRIPTION
- Adds contributors recognition and some nicer mrkdown formatting
- [Blog post](https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/#introducing-auto-generated-release-notes), [GitHub CLI teams own usage](https://github.com/cli/cli/pull/4512/files), [Docs 1](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes), [Docs 2](https://docs.github.com/en/rest/reference/repos#generate-release-notes-content-for-a-release)

<img src=https://github.blog/wp-content/uploads/2021/10/GitHub-new-releases-screenshot.png>