### PR TITLE
Removes transactions from dispatching message handlers

### DIFF
--- a/src/FplBot.Discord/Handlers/FplEvents/FixtureEventsHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/FixtureEventsHandler.cs
@@ -25,7 +25,10 @@ public class FixtureEventsHandler : IHandleMessages<FixtureEventsOccured>, IHand
 
         foreach (var sub in subs)
         {
-            await context.SendLocal(new PublishFixtureEventsToGuild(sub.GuildId, sub.ChannelId, message.FixtureEvents));
+            var options = new SendOptions();
+            options.RequireImmediateDispatch();
+            options.RouteToThisEndpoint();
+            await context.Send(new PublishFixtureEventsToGuild(sub.GuildId, sub.ChannelId, message.FixtureEvents), options);
         }
     }
 
@@ -43,6 +46,7 @@ public class FixtureEventsHandler : IHandleMessages<FixtureEventsOccured>, IHand
                 var sendOptions = new SendOptions();
                 sendOptions.DelayDeliveryWith(TimeSpan.FromSeconds(i));
                 sendOptions.RouteToThisEndpoint();
+
                 await context.Send(new PublishRichToGuildChannel(message.GuildId, message.ChannelId, eventMsg.Title, eventMsg.Details), sendOptions);
             }
         }

--- a/src/FplBot.Discord/Handlers/FplEvents/FixtureFulltimeHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/FixtureFulltimeHandler.cs
@@ -36,7 +36,13 @@ public class FixtureFulltimeHandler : IHandleMessages<FixtureFinished>
         foreach (var sub in subs)
         {
             if (sub.Subscriptions.ContainsSubscriptionFor(EventSubscription.FixtureFullTime))
-                await context.SendLocal(new PublishRichToGuildChannel(sub.GuildId, sub.ChannelId, $"ℹ️ {title}",$"{threadMessage}"));
+            {
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishRichToGuildChannel(sub.GuildId, sub.ChannelId, $"ℹ️ {title}",$"{threadMessage}"), options);
+            }
+
         }
     }
 }

--- a/src/FplBot.Discord/Handlers/FplEvents/GameweekFinishedHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/GameweekFinishedHandler.cs
@@ -34,7 +34,10 @@ public class GameweekFinishedHandler : IHandleMessages<GameweekFinished>,
         var allSubs = await _repo.GetAllGuildSubscriptions();
         foreach (var sub in allSubs)
         {
-            await context.SendLocal(new PublishGameweekFinishedToGuild(sub.GuildId, sub.ChannelId, sub.LeagueId, message.FinishedGameweek.Id));
+            var options = new SendOptions();
+            options.RequireImmediateDispatch();
+            options.RouteToThisEndpoint();
+            await context.Send(new PublishGameweekFinishedToGuild(sub.GuildId, sub.ChannelId, sub.LeagueId, message.FinishedGameweek.Id), options);
         }
     }
 

--- a/src/FplBot.Discord/Handlers/FplEvents/GameweekStartedHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/GameweekStartedHandler.cs
@@ -31,7 +31,10 @@ public class GameweekStartedHandler : IHandleMessages<GameweekJustBegan>, IHandl
         var subs = await _repo.GetAllGuildSubscriptions();
         foreach (var team in subs)
         {
-            await context.SendLocal(new ProcessGameweekStartedForGuildChannel(team.GuildId, team.ChannelId, notification.NewGameweek.Id));
+            var options = new SendOptions();
+            options.RequireImmediateDispatch();
+            options.RouteToThisEndpoint();
+            await context.Send(new ProcessGameweekStartedForGuildChannel(team.GuildId, team.ChannelId, notification.NewGameweek.Id), options);
         }
     }
 

--- a/src/FplBot.Discord/Handlers/FplEvents/InjuryUpdateHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/InjuryUpdateHandler.cs
@@ -30,7 +30,13 @@ public class InjuryUpdateHandler : IHandleMessages<InjuryUpdateOccured>
             foreach (var guildSub in guildSubs)
             {
                 if (guildSub.Subscriptions.ContainsSubscriptionFor(EventSubscription.InjuryUpdates))
-                    await context.SendLocal(new PublishRichToGuildChannel(guildSub.GuildId, guildSub.ChannelId, "ℹ️ Injury update", formatted));
+                {
+                    var options = new SendOptions();
+                    options.RequireImmediateDispatch();
+                    options.RouteToThisEndpoint();
+                    await context.Send(new PublishRichToGuildChannel(guildSub.GuildId, guildSub.ChannelId, "ℹ️ Injury update", formatted), options);
+                }
+
             }
         }
         else

--- a/src/FplBot.Discord/Handlers/FplEvents/LineupReadyHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/LineupReadyHandler.cs
@@ -24,7 +24,13 @@ public class LineupReadyHandler : IHandleMessages<LineupReady>
         foreach (var sub in subs)
         {
             if (sub.Subscriptions.ContainsSubscriptionFor(EventSubscription.Lineups))
-                await context.SendLocal(new PublishRichToGuildChannel(sub.GuildId, sub.ChannelId, $"ℹ️ {firstMessage}", $"{formattedLineup}"));
+            {
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishRichToGuildChannel(sub.GuildId, sub.ChannelId, $"ℹ️ {firstMessage}", $"{formattedLineup}"), options);
+            }
+
         }
     }
 }

--- a/src/FplBot.Discord/Handlers/FplEvents/NearDeadlineHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/NearDeadlineHandler.cs
@@ -27,8 +27,13 @@ public class NearDeadlineHandler :
         var text = $"@here ⏳Gameweek {message.GameweekNearingDeadline.Id} deadline in 60 minutes!";
         foreach (var guild in allGuilds)
         {
-            if(guild.Subscriptions.ContainsSubscriptionFor(EventSubscription.Deadlines))
-                await context.SendLocal(new PublishRichToGuildChannel(guild.GuildId, guild.ChannelId, "ℹ️ Deadline", text));
+            if (guild.Subscriptions.ContainsSubscriptionFor(EventSubscription.Deadlines))
+            {
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishRichToGuildChannel(guild.GuildId, guild.ChannelId, "ℹ️ Deadline", text), options);
+            }
         }
     }
 
@@ -39,8 +44,13 @@ public class NearDeadlineHandler :
         var text = $"⏳Gameweek {message.GameweekNearingDeadline.Id} deadline in 24 hours!";
         foreach (var guild in allGuilds)
         {
-            if(guild.Subscriptions.ContainsSubscriptionFor(EventSubscription.Deadlines))
-                await context.SendLocal(new PublishRichToGuildChannel(guild.GuildId, guild.ChannelId, "ℹ️ Deadline", text));
+            if (guild.Subscriptions.ContainsSubscriptionFor(EventSubscription.Deadlines))
+            {
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishRichToGuildChannel(guild.GuildId, guild.ChannelId, "ℹ️ Deadline", text), options);
+            }
         }
     }
 }

--- a/src/FplBot.Discord/Handlers/FplEvents/NewPlayersHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/NewPlayersHandler.cs
@@ -28,7 +28,10 @@ public class NewPlayersHandler : IHandleMessages<NewPlayersRegistered>
         {
             if (guildSub.Subscriptions.ContainsSubscriptionFor(EventSubscription.NewPlayers) && !string.IsNullOrEmpty(formatted))
             {
-                await context.SendLocal(new PublishRichToGuildChannel(guildSub.GuildId, guildSub.ChannelId,"ℹ️ New players", formatted));
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishRichToGuildChannel(guildSub.GuildId, guildSub.ChannelId,"ℹ️ New players", formatted), options);
             }
         }
     }

--- a/src/FplBot.Discord/Handlers/FplEvents/PriceChangeHandler.cs
+++ b/src/FplBot.Discord/Handlers/FplEvents/PriceChangeHandler.cs
@@ -34,7 +34,10 @@ public class PriceChangeHandler : IHandleMessages<PlayersPriceChanged>
             {
                 if (guildSub.Subscriptions.ContainsSubscriptionFor(EventSubscription.PriceChanges) && !string.IsNullOrEmpty(formatted))
                 {
-                    await context.SendLocal(new PublishRichToGuildChannel(guildSub.GuildId, guildSub.ChannelId, "ℹ️ Price changes", formatted));
+                    var options = new SendOptions();
+                    options.RequireImmediateDispatch();
+                    options.RouteToThisEndpoint();
+                    await context.Send(new PublishRichToGuildChannel(guildSub.GuildId, guildSub.ChannelId, "ℹ️ Price changes", formatted), options);
                 }
             }
         }

--- a/src/FplBot.Slack/Handlers/FplEvents/FixtureEventsHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/FixtureEventsHandler.cs
@@ -44,7 +44,10 @@ public class FixtureEventsHandler : IHandleMessages<FixtureEventsOccured>, IHand
 
         foreach (var slackTeam in slackTeams)
         {
-            await context.SendLocal(new PublishFixtureEventsToSlackWorkspace(slackTeam.TeamId, message.FixtureEvents));
+            var options = new SendOptions();
+            options.RequireImmediateDispatch();
+            options.RouteToThisEndpoint();
+            await context.Send(new PublishFixtureEventsToSlackWorkspace(slackTeam.TeamId, message.FixtureEvents), options);
         }
     }
 

--- a/src/FplBot.Slack/Handlers/FplEvents/FixtureFulltimeHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/FixtureFulltimeHandler.cs
@@ -44,7 +44,10 @@ public class FixtureFulltimeHandler : IHandleMessages<FixtureFinished>, IHandleM
         {
             if (slackTeam.HasRegisteredFor(EventSubscription.FixtureFullTime))
             {
-                await context.SendLocal(new PublishFulltimeMessageToSlackWorkspace(slackTeam.TeamId, title, threadMessage));
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishFulltimeMessageToSlackWorkspace(slackTeam.TeamId, title, threadMessage), options);
             }
         }
     }

--- a/src/FplBot.Slack/Handlers/FplEvents/GameweekFinishedHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/GameweekFinishedHandler.cs
@@ -35,7 +35,10 @@ internal class GameweekFinishedHandler : IHandleMessages<GameweekFinished>, IHan
         {
             if (team.HasRegisteredFor(EventSubscription.Standings))
             {
-                await context.SendLocal(new PublishStandingsToSlackWorkspace(team.TeamId, team.FplBotSlackChannel, team.FplbotLeagueId.Value, notification.FinishedGameweek.Id));
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishStandingsToSlackWorkspace(team.TeamId, team.FplBotSlackChannel, team.FplbotLeagueId.Value, notification.FinishedGameweek.Id), options);
             }
         }
     }

--- a/src/FplBot.Slack/Handlers/FplEvents/GameweekStartedHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/GameweekStartedHandler.cs
@@ -40,7 +40,10 @@ internal class GameweekStartedHandler : IHandleMessages<GameweekJustBegan>, IHan
         var teams = await _teamRepo.GetAllTeams();
         foreach (var team in teams)
         {
-            await context.SendLocal(new ProcessGameweekStartedForSlackWorkspace(team.TeamId, notification.NewGameweek.Id));
+            var options = new SendOptions();
+            options.RequireImmediateDispatch();
+            options.RouteToThisEndpoint();
+            await context.Send(new ProcessGameweekStartedForSlackWorkspace(team.TeamId, notification.NewGameweek.Id), options);
         }
     }
 

--- a/src/FplBot.Slack/Handlers/FplEvents/InjuryUpdateHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/InjuryUpdateHandler.cs
@@ -31,7 +31,12 @@ public class InjuryUpdateHandler : IHandleMessages<InjuryUpdateOccured>
             foreach (var slackTeam in slackTeams)
             {
                 if (slackTeam.HasRegisteredFor(EventSubscription.InjuryUpdates))
-                    await context.SendLocal(new PublishToSlack(slackTeam.TeamId, slackTeam.FplBotSlackChannel, formatted));
+                {
+                    var options = new SendOptions();
+                    options.RequireImmediateDispatch();
+                    options.RouteToThisEndpoint();
+                    await context.Send(new PublishToSlack(slackTeam.TeamId, slackTeam.FplBotSlackChannel, formatted), options);
+                }
             }
         }
         else

--- a/src/FplBot.Slack/Handlers/FplEvents/LineupReadyHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/LineupReadyHandler.cs
@@ -31,8 +31,10 @@ public class LineupReadyHandler : IHandleMessages<LineupReady>, IHandleMessages<
         {
             if (slackTeam.HasRegisteredFor(EventSubscription.Lineups))
             {
-                var command = new PublishLineupsToSlackWorkspace(slackTeam.TeamId, message.Lineup);
-                await context.SendLocal(command);
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishLineupsToSlackWorkspace(slackTeam.TeamId, message.Lineup), options);
             }
         }
     }
@@ -48,13 +50,16 @@ public class LineupReadyHandler : IHandleMessages<LineupReady>, IHandleMessages<
         if (res.Ok)
         {
             var formattedLineup = Formatter.FormatLineup(lineups);
-            await context.SendLocal(new PublishSlackThreadMessage
+            var options = new SendOptions();
+            options.RequireImmediateDispatch();
+            options.RouteToThisEndpoint();
+            await context.Send(new PublishSlackThreadMessage
             (
                 message.WorkspaceId,
                 team.FplBotSlackChannel,
                 res.ts,
                 formattedLineup
-            ));
+            ),options);
         }
     }
 }

--- a/src/FplBot.Slack/Handlers/FplEvents/NearDeadlineHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/NearDeadlineHandler.cs
@@ -43,7 +43,10 @@ public class NearDeadlineHandler :
             {
                 var text = $"<!channel> ⏳ Gameweek {message.GameweekNearingDeadline.Id} deadline in 60 minutes!";
                 var command = new PublishToSlack(team.TeamId, team.FplBotSlackChannel, text);
-                await context.SendLocal(command);
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(command, options);
             }
         }
     }
@@ -58,7 +61,10 @@ public class NearDeadlineHandler :
             if (team.HasRegisteredFor(EventSubscription.Deadlines))
             {
                 var command = new PublishDeadlineNotificationToSlackWorkspace(team.TeamId, message.GameweekNearingDeadline);
-                await context.SendLocal(command);
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(command, options);
             }
         }
     }

--- a/src/FplBot.Slack/Handlers/FplEvents/NewPlayerHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/NewPlayerHandler.cs
@@ -30,7 +30,10 @@ public class NewPlayerHandler : IHandleMessages<NewPlayersRegistered>, IHandleMe
         {
             if (slackTeam.HasRegisteredFor(EventSubscription.NewPlayers))
             {
-                await context.SendLocal(new PublishNewPlayersToSlackWorkspace(slackTeam.TeamId, notification.NewPlayers));
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishNewPlayersToSlackWorkspace(slackTeam.TeamId, notification.NewPlayers), options);
             }
         }
     }

--- a/src/FplBot.Slack/Handlers/FplEvents/PriceChangeHandler.cs
+++ b/src/FplBot.Slack/Handlers/FplEvents/PriceChangeHandler.cs
@@ -30,7 +30,10 @@ public class PriceChangeHandler : IHandleMessages<PlayersPriceChanged>, IHandleM
         {
             if (slackTeam.HasRegisteredFor(EventSubscription.PriceChanges))
             {
-                await context.SendLocal(new PublishPriceChangesToSlackWorkspace(slackTeam.TeamId, notification.PlayersWithPriceChanges.ToList()));
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishPriceChangesToSlackWorkspace(slackTeam.TeamId, notification.PlayersWithPriceChanges.ToList()), options);
             }
         }
     }


### PR DESCRIPTION
**Bug:**
* On each FPL event, we loop all fplbot installs and send a command for each individual workspace/server. 
* All the send operations are enlisted in a transaction by NServicebus (default behaviour).
* The Azure Service Bus transport we use has a limit of 100 messages pr transaction.
* At some point we hit a total no of slack workspaces + discord servers to be >= 100. 

**Fix:**
Every handler that sends an unknown count of messages needs to either
1) batch send: keep transactions, but send in a way that number of messages are always below 100
2) disable transactions. 

Since we don't do _other_ work that could lead to failure inside the dispatcher loops, I think it's ok to simply disable transactions in those.

Our (pseudo) code:
```csharp
foreach(sub in subs){
  await sendCommand(sub);
}
```

Sample code that _could_ lead to unwanted behaviour (when transcations are disabled, and retries occur):

```csharp
foreach(sub in subs){
  await doStuffThatCouldFail(); 
  await sendCommand(sub);
}
```

If `doStuffThatCouldFail` fails and we don't enlist the dispatch handler in a ts, a retry of the dispatch handler would lead to duplicate messages to servers that successfully received a command before the failure.

**Sources**
- ASB only supports 100 messages in a single transaction, https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas
- `SendOptions.RequireImmediateDispatch()` disables transactions when sending commands, https://docs.particular.net/nservicebus/messaging/send-a-message#dispatching-a-message-immediately