### PR TITLE
Discord: don't put unauthorized message to error queue

### DIFF
--- a/src/FplBot.Discord/Handlers/PublishToGuildHandler.cs
+++ b/src/FplBot.Discord/Handlers/PublishToGuildHandler.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using Discord.Net.HttpClients;
 using FplBot.Messaging.Contracts.Commands.v1;
+using Microsoft.Extensions.Logging;
 using NServiceBus;
 
 namespace FplBot.Discord.Handlers;
@@ -9,10 +11,12 @@ public class PublishToGuildHandler :
     IHandleMessages<PublishRichToGuildChannel>
 {
     private readonly DiscordClient _discordClient;
+    private readonly ILogger<PublishToGuildHandler> _logger;
 
-    public PublishToGuildHandler(DiscordClient discordClient)
+    public PublishToGuildHandler(DiscordClient discordClient, ILogger<PublishToGuildHandler> logger)
     {
         _discordClient = discordClient;
+        _logger = logger;
     }
 
     public async Task Handle(PublishToGuildChannel message, IMessageHandlerContext context)
@@ -22,6 +26,16 @@ public class PublishToGuildHandler :
 
     public async Task Handle(PublishRichToGuildChannel message, IMessageHandlerContext context)
     {
-        await _discordClient.ChannelMessagePost(message.ChannelId, new DiscordClient.RichEmbed(message.Title, message.Description));
+        try
+        {
+            await _discordClient.ChannelMessagePost(message.ChannelId, new DiscordClient.RichEmbed(message.Title, message.Description));
+        }
+        catch (HttpRequestException hre) when (hre.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            // Scenarios:
+            // - Bot uninstalled
+            // - Setup a subscription in a channel without giving the bot permissions (fplbot role needs access)
+            _logger.LogWarning("Unauthorized to post to Discord channel {channel}", message.ChannelId);
+        }
     }
 }


### PR DESCRIPTION
Discord scenarios:
- Bot uninstalled (we don't get notice from Discord on uninstalls like we do for Slack)
- Setup a subscription in a channel without giving the bot permissions (fplbot role needs access if private discord channel).

Not sure if we can diff between an uninstall or private channel yet. Might want to just delete the Discord server and/or the sub if we cannot post to any channel in a server. 