### PR TITLE
Large leagues: minimize large gw-started content to stats/links

### DIFF
--- a/src/FplBot.Formatting/Helpers/ICaptainsByGameWeek.cs
+++ b/src/FplBot.Formatting/Helpers/ICaptainsByGameWeek.cs
@@ -1,9 +1,9 @@
-using System.Threading.Tasks;
-
 namespace FplBot.Formatting.Helpers;
 
 public interface ICaptainsByGameWeek
 {
-    Task<string> GetCaptainsByGameWeek(int gameweek, int leagueId, bool includeExternalLinks = true);
-    Task<string> GetCaptainsChartByGameWeek(int gameweek, int leagueId);
+    Task<string> GetCaptainsByGameWeek(int gameweek, IEnumerable<EntryCaptainPick> entryCaptainPicks, bool includeExternalLinks = true);
+    Task<string> GetCaptainsChartByGameWeek(int gameweek, IEnumerable<EntryCaptainPick> entryCaptainPicks);
+    Task<string> GetCaptainsStatsByGameWeek(IEnumerable<EntryCaptainPick> entryCaptainPicks, bool includeHeader = true);
+    Task<IEnumerable<EntryCaptainPick>> GetEntryCaptainPicks(int gameweek, int leagueId);
 }

--- a/src/FplBot.Slack/Handlers/SlackEvents/FplCaptainCommandHandler.cs
+++ b/src/FplBot.Slack/Handlers/SlackEvents/FplCaptainCommandHandler.cs
@@ -51,9 +51,10 @@ internal class FplCaptainCommandHandler : HandleAppMentionBase
         string outgoingMessage;
         if (setup.FplbotLeagueId.HasValue)
         {
+            var captainPicks = await _captainsByGameWeek.GetEntryCaptainPicks(gameWeek.Value, setup.FplbotLeagueId.Value);
             outgoingMessage = isChartRequest
-                ? await _captainsByGameWeek.GetCaptainsChartByGameWeek(gameWeek.Value, setup.FplbotLeagueId.Value)
-                : await _captainsByGameWeek.GetCaptainsByGameWeek(gameWeek.Value, setup.FplbotLeagueId.Value);
+                ? await _captainsByGameWeek.GetCaptainsChartByGameWeek(gameWeek.Value, captainPicks)
+                : await _captainsByGameWeek.GetCaptainsByGameWeek(gameWeek.Value, captainPicks);
         }
         else
         {


### PR DESCRIPTION
Reduces pushing large content to clients. Some servers/worksapces with subs for larger leagues does not have the same connection to each individual FPL manager as in the smaller leagues (say, a smaller group of friends/colleagues). For these larger leagues, we just push stats instead with a link to full details on our web site. 

**Smaller league**
<img width=300 src=https://user-images.githubusercontent.com/206726/144071493-e99df210-0c50-48c3-978c-8dacdccaf553.png>

**Larger league**
<img width=300 src=https://user-images.githubusercontent.com/206726/144071420-da4b2955-fefe-4ef0-8a0f-5f56567fb590.png>
