### PR TITLE
Game is updating

### DIFF
--- a/src/Fpl.EventPublishers.Console/HostBuilderExtensions.cs
+++ b/src/Fpl.EventPublishers.Console/HostBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class HostBuilderExtensions
     private static EndpointConfiguration AzureServiceBusEndpoint(this HostBuilderContext context, string endpointPostfix = null)
     {
         endpointPostfix = string.IsNullOrEmpty(endpointPostfix) ? string.Empty : $".{endpointPostfix}";
-        string endpointName = $"Fpl.EventPublisher.{endpointPostfix}";
+        string endpointName = $"Fpl.EventPublisher{endpointPostfix}";
         Console.WriteLine($"Endpoint: {endpointName}");
         var endpointConfiguration = new EndpointConfiguration(endpointName);
         endpointConfiguration.SendOnly();

--- a/src/Fpl.EventPublishers.Console/HostBuilderExtensions.cs
+++ b/src/Fpl.EventPublishers.Console/HostBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class HostBuilderExtensions
     private static EndpointConfiguration AzureServiceBusEndpoint(this HostBuilderContext context, string endpointPostfix = null)
     {
         endpointPostfix = string.IsNullOrEmpty(endpointPostfix) ? string.Empty : $".{endpointPostfix}";
-        string endpointName = $"Fpl.EventPublisher";
+        string endpointName = $"Fpl.EventPublisher.{endpointPostfix}";
         Console.WriteLine($"Endpoint: {endpointName}");
         var endpointConfiguration = new EndpointConfiguration(endpointName);
         endpointConfiguration.SendOnly();

--- a/src/Fpl.EventPublishers/RecurringActions/MatchDayStatusRecurringAction.cs
+++ b/src/Fpl.EventPublishers/RecurringActions/MatchDayStatusRecurringAction.cs
@@ -6,19 +6,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Fpl.EventPublishers.RecurringActions;
 
-internal class MatchDayStatusRecurringAction : IRecurringAction 
+internal class MatchDayStatusRecurringAction : IRecurringAction
 {
     private readonly MatchDayStatusMonitor _monitor;
-    private readonly ILogger<GameweekLifecycleMonitor> _logger;
+    private readonly ILogger<MatchDayStatusRecurringAction> _logger;
 
-    public MatchDayStatusRecurringAction(MatchDayStatusMonitor monitor, ILogger<GameweekLifecycleMonitor> logger)
+    public MatchDayStatusRecurringAction(MatchDayStatusMonitor monitor, ILogger<MatchDayStatusRecurringAction> logger)
     {
         _monitor = monitor;
         _logger = logger;
     }
 
     public async Task Process(CancellationToken token)
-    {            
+    {
         using (_logger.BeginCorrelationScope())
         {
             _logger.LogInformation($"Running {nameof(MatchDayStatusRecurringAction)}");

--- a/src/FplBot.EventHandlers.Console/FplBot.EventHandlers.Console.csproj
+++ b/src/FplBot.EventHandlers.Console/FplBot.EventHandlers.Console.csproj
@@ -6,33 +6,33 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="MinimalHttpLogger" Version="0.1.2" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.9.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.6" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
-    <PackageReference Include="Slackbot.Net.SlackClients.Http" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0"/>
+    <PackageReference Include="MinimalHttpLogger" Version="0.1.2"/>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0"/>
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.9.0"/>
+    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1"/>
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0"/>
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.6"/>
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0"/>
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0"/>
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0"/>
+    <PackageReference Include="Slackbot.Net.SlackClients.Http" Version="6.0.1"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ext\Discord.Net.HttpClients\Discord.Net.HttpClients.csproj" />
-    <ProjectReference Include="..\Fpl.Client\Fpl.Client.csproj" />
-    <ProjectReference Include="..\FplBot.Data\FplBot.Data.csproj" />
-    
-    
-    <ProjectReference Include="..\FplBot.Formatting\FplBot.Formatting.csproj" />
-    <ProjectReference Include="..\FplBot.Messaging.Contracts\FplBot.Messaging.Contracts.csproj" />
+    <ProjectReference Include="..\ext\Discord.Net.HttpClients\Discord.Net.HttpClients.csproj"/>
+    <ProjectReference Include="..\Fpl.Client\Fpl.Client.csproj"/>
+    <ProjectReference Include="..\FplBot.Data\FplBot.Data.csproj"/>
+
+
+    <ProjectReference Include="..\FplBot.Formatting\FplBot.Formatting.csproj"/>
+    <ProjectReference Include="..\FplBot.Messaging.Contracts\FplBot.Messaging.Contracts.csproj"/>
   </ItemGroup>
 
   <!-- Don't remove. No direct usages, but NSB uses assembly scanning to resolve handlers/setup subs -->
-  <ItemGroup>    
-    <ProjectReference Include="..\FplBot.EventHandlers.Discord\FplBot.EventHandlers.Discord.csproj" />
-    <ProjectReference Include="..\FplBot.EventHandlers.Slack\FplBot.EventHandlers.Slack.csproj" />
+  <ItemGroup>
+    <ProjectReference Include="..\FplBot.EventHandlers.Discord\FplBot.EventHandlers.Discord.csproj"/>
+    <ProjectReference Include="..\FplBot.EventHandlers.Slack\FplBot.EventHandlers.Slack.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/FplBot.EventHandlers.Console/HostBuilderExtensions.cs
+++ b/src/FplBot.EventHandlers.Console/HostBuilderExtensions.cs
@@ -82,7 +82,7 @@ public static class HostBuilderExtensions
     private static EndpointConfiguration AzureServiceBusEndpoint(this HostBuilderContext context, string chatbot, string excludeHandlers, string endpointPostfix = null)
     {
         endpointPostfix = string.IsNullOrEmpty(endpointPostfix) ? string.Empty : $".{endpointPostfix}";
-        string endpointName = $"FplBot.EventHandlers.{chatbot}";
+        string endpointName = $"FplBot.EventHandlers.{chatbot}{endpointPostfix}";
         Console.WriteLine($"Endpoint: {endpointName}");
         var endpointConfiguration = new EndpointConfiguration(endpointName);
         endpointConfiguration.UseSerialization<NewtonsoftSerializer>();

--- a/src/FplBot.EventHandlers.Console/HostBuilderExtensions.cs
+++ b/src/FplBot.EventHandlers.Console/HostBuilderExtensions.cs
@@ -135,7 +135,7 @@ public static class HostBuilderExtensions
             var metrics = endpointConfiguration.EnableMetrics();
             metrics.SendMetricDataToServiceControl(
                 serviceControlMetricsAddress: GetServiceControlMonitoringQueue(context.HostingEnvironment),
-                interval: TimeSpan.FromSeconds(2)
+                interval: TimeSpan.FromSeconds(60)
             );
         }
 

--- a/src/FplBot.Formatting/Helpers/LeagueEntriesByGameweek.cs
+++ b/src/FplBot.Formatting/Helpers/LeagueEntriesByGameweek.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Net;
 using Fpl.Client.Abstractions;
 using Fpl.Client.Models;
 using Microsoft.Extensions.Logging;
@@ -40,11 +37,20 @@ public class LeagueEntriesByGameweek : ILeagueEntriesByGameweek
 
             return entryDictionary;
         }
+        catch (HttpRequestException hre) when (LogWarning(hre, gw, leagueId))
+        {
+            return Enumerable.Empty<GameweekEntry>();
+        }
         catch (Exception e)
         {
             _logger.LogError(e, e.Message);
             return Enumerable.Empty<GameweekEntry>();
         }
+    }
+    private bool LogWarning(HttpRequestException hre, int gw, int leagueId)
+    {
+        _logger.LogWarning("Could not get entries in {GW} for {LeagueId}", gw, leagueId);
+        return hre.StatusCode == HttpStatusCode.NotFound;
     }
 
 }

--- a/src/FplBot.Formatting/TransfersByGameWeek.cs
+++ b/src/FplBot.Formatting/TransfersByGameWeek.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Fpl.Client;
@@ -70,14 +71,22 @@ public class TransfersByGameWeek : ITransfersByGameWeek
 
             return playerTransfers.ToArray();
         }
+        catch (HttpRequestException hre) when (LogWarning(hre, gw, leagueId))
+        {
+            return Enumerable.Empty<Transfer>();
+        }
         catch (Exception e)
         {
             _logger.LogError(e, e.Message);
-
             return Enumerable.Empty<Transfer>();
         }
     }
 
+    private bool LogWarning(HttpRequestException hre, int gw, int leagueId)
+    {
+        _logger.LogWarning("Could not get transfers in {GW} for {LeagueId}", gw, leagueId);
+        return hre.StatusCode == HttpStatusCode.NotFound;
+    }
 
     public record TransfersMessage(string Message);
 

--- a/src/FplBot.WebApi/Controllers/DebugController.cs
+++ b/src/FplBot.WebApi/Controllers/DebugController.cs
@@ -46,7 +46,7 @@ public class DebugController
         FixtureScore fixtureScore = new(home, away, 35, 0, 1);
         Dictionary<StatType,List<PlayerEvent>> statMap = new();
         PlayerDetails playerDetails1 = new(1, "Testerson");
-        PlayerDetails playerDetails2 = new(2, "Yolerson");
+        PlayerDetails playerDetails2 = new(2, Environment.MachineName);
         TeamType teamDetails = TeamType.Home;
 
         List<PlayerEvent> playerEvents = new()

--- a/src/FplBot.WebApi/FplBot.WebApi.csproj
+++ b/src/FplBot.WebApi/FplBot.WebApi.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>    
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.10" />
+    
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
@@ -16,11 +17,11 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     <PackageReference Include="AspNet.Security.OAuth.Slack" Version="5.0.11" />
-    
+    <PackageReference Include="NServiceBus" Version="7.5.0" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.9.0" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />    
     <PackageReference Include="MediatR" Version="9.0.0" />
 
   </ItemGroup>

--- a/src/FplBot.WebApi/Infrastructure/HostBuilderExtensions.cs
+++ b/src/FplBot.WebApi/Infrastructure/HostBuilderExtensions.cs
@@ -31,7 +31,7 @@ public static class HostBuilderExtensions
     private static EndpointConfiguration AzureServiceBusEndpoint(this HostBuilderContext context, string endpointPostfix = null)
     {
         endpointPostfix = string.IsNullOrEmpty(endpointPostfix) ? string.Empty : $".{endpointPostfix}";
-        string endpointName = $"FplBot.WebApi";
+        string endpointName = $"FplBot.WebApi{endpointPostfix}";
         Console.WriteLine($"Endpoint: {endpointName}");
         var endpointConfiguration = new EndpointConfiguration(endpointName);
         endpointConfiguration.UseSerialization<NewtonsoftSerializer>();
@@ -71,22 +71,8 @@ public static class HostBuilderExtensions
         recoverabilty.Immediate(s => s.NumberOfRetries(0));
         recoverabilty.Delayed(s => s.NumberOfRetries(3).TimeIncrease(TimeSpan.FromSeconds(20)));
 
-        // ℹ️ Disabled in dev to decrease webapp startup time
-        //
-        // Enable when you want to create new queues (i.e. new developer and/or endpoint) without
-        // using the `asb-transport` CLI tool
-        // if (!context.HostingEnvironment.IsDevelopment())
-        // {
-            endpointConfiguration.EnableInstallers();
-        // }
+        endpointConfiguration.EnableInstallers();
 
-        // ℹ️ Disabled in dev To decrease web app startup time
-        //
-        // Enable interim if you want to test _new_ events and/or commands
-        if(context.HostingEnvironment.IsDevelopment())
-        {
-            endpointConfiguration.DisableFeature<AutoSubscribe>();
-        }
 
         if (!context.HostingEnvironment.IsDevelopment())
         {


### PR DESCRIPTION
- Logs WRN instead of ERR when 529 Service Unavailable from the FPL API (a.k.a. "The game is updating").
- Uses weird Serilog trick to keep scope (correlationId) in stacktraces: https://andrewlock.net/how-to-include-scopes-when-logging-exceptions-in-asp-net-core/#using-exception-filters-to-capture-scopes
