### PR TITLE
Adds notifications when a fixture is off

### DIFF
--- a/src/Fpl.EventPublishers/Extensions/ILoggerExtensions.cs
+++ b/src/Fpl.EventPublishers/Extensions/ILoggerExtensions.cs
@@ -4,12 +4,24 @@ namespace Fpl.EventPublishers.Extensions;
 
 internal static class ILoggerExtensions
 {
-    // Re-using the same as the correlationId ASP.NET Middleware, but re-defining it here to avoid dependency & it has a private accessor anyways :/ 
+    // Re-using the same as the correlationId ASP.NET Middleware, but re-defining it here to avoid dependency & it has a private accessor anyways :/
     // https://github.com/ekmsystems/serilog-enrichers-correlation-id/blob/master/src/Serilog.Enrichers.CorrelationId/Enrichers/CorrelationIdEnricher.cs#L15
     private const string CorrelationId = "CorrelationId";
+    private const string Context = "Context";
 
     public static IDisposable BeginCorrelationScope(this ILogger logger)
     {
         return logger.BeginScope(new Dictionary<string, object> {[CorrelationId] = Guid.NewGuid()});
+    }
+
+    public static IDisposable AddContext(this ILogger logger, string context)
+    {
+        return logger.BeginScope(new Dictionary<string, object> {[Context] = context});
+    }
+
+    public static IDisposable AddContext(this ILogger logger, params Tuple<string,string>[] keyvaluepair)
+    {
+        var dictionary = keyvaluepair.ToDictionary<Tuple<string, string>, string, object>(kvp => kvp.Item1, kvp => kvp.Item2);
+        return logger.BeginScope(dictionary);
     }
 }

--- a/src/Fpl.EventPublishers/Mediators/LineupsMediator.cs
+++ b/src/Fpl.EventPublishers/Mediators/LineupsMediator.cs
@@ -1,4 +1,5 @@
 using Fpl.EventPublishers.Events;
+using Fpl.EventPublishers.Extensions;
 using Fpl.EventPublishers.States;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -31,25 +32,28 @@ internal class LineupsHandler :
         {
             initId++;
         }
-
+        using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekMonitoringStarted), initId.ToString()));
         _logger.LogInformation("Init {Gameweek}", initId);
         return _matchState.Reset(initId);
     }
 
     public Task Handle(GameweekJustBegan notification, CancellationToken cancellationToken)
     {
+        using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekJustBegan), notification.Gameweek.Id.ToString()));
         _logger.LogInformation("Resetting state. Gameweek {Gameweek} just began.", notification.Gameweek.Id);
         return _matchState.Reset(notification.Gameweek.Id);
     }
 
     public Task Handle(GameweekCurrentlyOnGoing notification, CancellationToken cancellationToken)
     {
+        using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekCurrentlyOnGoing), notification.Gameweek.Id.ToString()));
         _logger.LogInformation("Refreshing state for ongoing gw {Gameweek}", notification.Gameweek.Id);
         return _matchState.Refresh(notification.Gameweek.Id);
     }
 
     public Task Handle(GameweekCurrentlyFinished notification, CancellationToken cancellationToken)
     {
+        using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekCurrentlyFinished), (notification.Gameweek.Id+1).ToString()));
         _logger.LogInformation("Refreshing state for finished gw {Gameweek}. Using next gw {NextGameweek}", notification.Gameweek.Id, notification.Gameweek.Id + 1);
         return _matchState.Refresh(notification.Gameweek.Id + 1); // monitor next gameweeks matches, since current = finished
     }

--- a/src/Fpl.EventPublishers/Mediators/LineupsMediator.cs
+++ b/src/Fpl.EventPublishers/Mediators/LineupsMediator.cs
@@ -26,25 +26,31 @@ internal class LineupsHandler :
 
     public Task Handle(GameweekMonitoringStarted notification, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Init");
-        return _matchState.Reset(notification.CurrentGameweek.Id);
+        var initId = notification.CurrentGameweek.Id;
+        if (notification.CurrentGameweek.IsFinished)
+        {
+            initId++;
+        }
+
+        _logger.LogInformation("Init {Gameweek}", initId);
+        return _matchState.Reset(initId);
     }
 
     public Task Handle(GameweekJustBegan notification, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Resetting state");
+        _logger.LogInformation("Resetting state. Gameweek {Gameweek} just began.", notification.Gameweek.Id);
         return _matchState.Reset(notification.Gameweek.Id);
     }
 
     public Task Handle(GameweekCurrentlyOnGoing notification, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Refreshing state for ongoing gw");
+        _logger.LogInformation("Refreshing state for ongoing gw {Gameweek}", notification.Gameweek.Id);
         return _matchState.Refresh(notification.Gameweek.Id);
     }
 
     public Task Handle(GameweekCurrentlyFinished notification, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Refreshing state for finished gw");
+        _logger.LogInformation("Refreshing state for finished gw {Gameweek}. Using next gw {NextGameweek}", notification.Gameweek.Id, notification.Gameweek.Id + 1);
         return _matchState.Refresh(notification.Gameweek.Id + 1); // monitor next gameweeks matches, since current = finished
     }
 }

--- a/src/Fpl.EventPublishers/Mediators/StateEventsHandler.cs
+++ b/src/Fpl.EventPublishers/Mediators/StateEventsHandler.cs
@@ -1,4 +1,5 @@
 using Fpl.EventPublishers.Events;
+using Fpl.EventPublishers.Extensions;
 using Fpl.EventPublishers.States;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -25,24 +26,28 @@ internal class StateMediator :
 
     public Task Handle(GameweekMonitoringStarted notification, CancellationToken cancellationToken)
     {
+        using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekMonitoringStarted), notification.CurrentGameweek.Id.ToString()));
         _logger.LogInformation("Init");
         return _state.Reset(notification.CurrentGameweek.Id);
     }
 
     public Task Handle(GameweekJustBegan notification, CancellationToken cancellationToken)
     {
+        using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekJustBegan), notification.Gameweek.Id.ToString()));
         _logger.LogInformation("Getting ready to rumble");
         return _state.Reset(notification.Gameweek.Id);
     }
 
     public Task Handle(GameweekCurrentlyOnGoing notification, CancellationToken cancellationToken)
     {
+        using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekCurrentlyOnGoing), notification.Gameweek.Id.ToString()));
         _logger.LogInformation("Refreshing state for ongoing gw");
         return _state.Refresh(notification.Gameweek.Id);
     }
 
     public Task Handle(GameweekCurrentlyFinished notification, CancellationToken cancellationToken)
     {
+        using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekCurrentlyFinished), notification.Gameweek.Id.ToString()));
         _logger.LogInformation("Refreshing state - finished gw");
         return _state.Refresh(notification.Gameweek.Id);
     }

--- a/src/Fpl.EventPublishers/RecurringActions/GameweekLifecycleRecurringAction.cs
+++ b/src/Fpl.EventPublishers/RecurringActions/GameweekLifecycleRecurringAction.cs
@@ -19,11 +19,9 @@ internal class GameweekLifecycleRecurringAction : IRecurringAction
 
     public async Task Process(CancellationToken token)
     {
-        using (_logger.BeginCorrelationScope())
-        {
-            _logger.LogInformation($"Running {nameof(GameweekLifecycleRecurringAction)}");
-            await _monitor.EveryOtherMinuteTick(token);
-        }
+        using var scope = _logger.BeginCorrelationScope();
+        _logger.LogInformation($"Running {nameof(GameweekLifecycleRecurringAction)}");
+        await _monitor.EveryOtherMinuteTick(token);
     }
 
     public string Cron => CronPatterns.EveryOtherMinute;

--- a/src/Fpl.EventPublishers/RecurringActions/MatchDayStatusRecurringAction.cs
+++ b/src/Fpl.EventPublishers/RecurringActions/MatchDayStatusRecurringAction.cs
@@ -19,11 +19,10 @@ internal class MatchDayStatusRecurringAction : IRecurringAction
 
     public async Task Process(CancellationToken token)
     {
-        using (_logger.BeginCorrelationScope())
-        {
-            _logger.LogInformation($"Running {nameof(MatchDayStatusRecurringAction)}");
-            await _monitor.EveryFiveMinutesTick(token);
-        }
+        using var scope = _logger.BeginCorrelationScope();
+        using var scope2 = _logger.AddContext("MatchdaystatusCheck");
+        _logger.LogInformation($"Running {nameof(MatchDayStatusRecurringAction)}");
+        await _monitor.EveryFiveMinutesTick(token);
     }
 
     public string Cron => CronPatterns.EveryFiveMinutesAt40seconds;

--- a/src/Fpl.EventPublishers/RecurringActions/NearDeadlineRecurringAction.cs
+++ b/src/Fpl.EventPublishers/RecurringActions/NearDeadlineRecurringAction.cs
@@ -19,11 +19,10 @@ internal class NearDeadlineRecurringAction : IRecurringAction
 
     public async Task Process(CancellationToken token)
     {
-        using (_logger.BeginCorrelationScope())
-        {
-            _logger.LogInformation($"Running {nameof(NearDeadlineRecurringAction)}");
-            await _monitor.EveryMinuteTick();
-        }
+        using var scope = _logger.BeginCorrelationScope();
+        using var scope2 = _logger.AddContext("NeardeadlineCheck");
+        _logger.LogInformation($"Running {nameof(NearDeadlineRecurringAction)}");
+        await _monitor.EveryMinuteTick();
     }
 
     public string Cron => CronPatterns.EveryMinuteAt20Seconds;

--- a/src/Fpl.EventPublishers/States/GameweekLifecycleMonitor.cs
+++ b/src/Fpl.EventPublishers/States/GameweekLifecycleMonitor.cs
@@ -32,7 +32,7 @@ internal class GameweekLifecycleMonitor
         {
             globalSettings = await _gwClient.GetGlobalSettings();
         }
-        catch (Exception hre) when (LogError(hre))
+        catch (Exception e) when (LogError(e))
         {
             return;
         }

--- a/src/Fpl.EventPublishers/States/GameweekLifecycleMonitor.cs
+++ b/src/Fpl.EventPublishers/States/GameweekLifecycleMonitor.cs
@@ -32,7 +32,7 @@ internal class GameweekLifecycleMonitor
         {
             globalSettings = await _gwClient.GetGlobalSettings();
         }
-        catch (HttpRequestException hre) when (LogError(hre))
+        catch (Exception hre) when (LogError(hre))
         {
             return;
         }
@@ -101,9 +101,17 @@ internal class GameweekLifecycleMonitor
         return isFirstGameweekBeginning && isFirstGameweekChangeToCurrent;
     }
 
-    private bool LogError(HttpRequestException hre)
+    private bool LogError(Exception e)
     {
-        _logger.LogWarning("Game is updating ({StatusCode})", hre.StatusCode);
-        return hre.StatusCode == HttpStatusCode.ServiceUnavailable;
+        if (e is HttpRequestException { StatusCode: HttpStatusCode.ServiceUnavailable })
+        {
+            _logger.LogWarning("Game is updating");
+        }
+        else
+        {
+            _logger.LogError(e, e.Message);
+        }
+
+        return true;
     }
 }

--- a/src/Fpl.EventPublishers/States/LineupState.cs
+++ b/src/Fpl.EventPublishers/States/LineupState.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Fpl.Client.Abstractions;
 using Fpl.Client.Models;
 using Fpl.EventPublishers.Abstractions;
+using Fpl.EventPublishers.Extensions;
 using Fpl.EventPublishers.Models.Mappers;
 using FplBot.Messaging.Contracts.Events.v1;
 using Microsoft.Extensions.Logging;
@@ -80,6 +81,7 @@ internal class LineupState
 
     private async Task CheckForRemovedFixtures(ICollection<Fixture> updatedFixtures, int gw)
     {
+        using var scope = _logger.AddContext("CheckForRemovedFixtures");
         var currentEvent = _currentFixtures.First().Event;
         var updatedEvent = updatedFixtures.First().Event;
         if (updatedEvent != currentEvent)
@@ -104,6 +106,10 @@ internal class LineupState
                         new (awayTeam.Id, awayTeam.Name, awayTeam.ShortName));
                     await _session.Publish(new FixtureRemovedFromGameweek(gw, removedFixture));
                 }
+                else
+                {
+                    _logger.LogDebug("Fixture {FixtureId} not removed", currentFixture.Id);
+                }
             }
             catch (Exception e) when (LogError(e))
             {
@@ -113,6 +119,7 @@ internal class LineupState
 
     private async Task CheckForLineups(ICollection<Fixture> fixtures)
     {
+        using var scope = _logger.AddContext("CheckForLineups");
         foreach (var fixture in fixtures)
         {
             try

--- a/src/Fpl.EventPublishers/States/LineupState.cs
+++ b/src/Fpl.EventPublishers/States/LineupState.cs
@@ -80,6 +80,14 @@ internal class LineupState
 
     private async Task CheckForRemovedFixtures(ICollection<Fixture> updatedFixtures, int gw)
     {
+        var currentEvent = _currentFixtures.First().Event;
+        var updatedEvent = updatedFixtures.First().Event;
+        if (updatedEvent != currentEvent)
+        {
+            _logger.LogWarning("Checking fixtures for different gameweek. {Current} vs {Updated}. Aborting.", currentEvent, updatedEvent );
+            return;
+        }
+
         foreach (var currentFixture in _currentFixtures)
         {
             try

--- a/src/Fpl.EventPublishers/States/LineupState.cs
+++ b/src/Fpl.EventPublishers/States/LineupState.cs
@@ -67,7 +67,6 @@ internal class LineupState
         try
         {
             updatedFixtures = await _fixtureClient.GetFixturesByGameweek(gw);
-
         }
         catch (Exception e) when (LogError(e))
         {

--- a/src/Fpl.EventPublishers/States/LineupState.cs
+++ b/src/Fpl.EventPublishers/States/LineupState.cs
@@ -3,6 +3,7 @@ using Fpl.Client.Abstractions;
 using Fpl.Client.Models;
 using Fpl.EventPublishers.Abstractions;
 using Fpl.EventPublishers.Models.Mappers;
+using FplBot.Messaging.Contracts.Events.v1;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
 
@@ -12,33 +13,36 @@ internal class LineupState
 {
     private readonly IFixtureClient _fixtureClient;
     private readonly IGetMatchDetails _scraperApi;
+    private readonly IGlobalSettingsClient _globalSettingsClient;
     private readonly IMessageSession _session;
     private readonly ILogger<LineupState> _logger;
     private readonly Dictionary<int, MatchDetails> _matchDetails;
+    private ICollection<Fixture> _oldFixtures;
 
-    public LineupState(IFixtureClient fixtureClient, IGetMatchDetails scraperApi, IMessageSession session, ILogger<LineupState> logger)
+    public LineupState(IFixtureClient fixtureClient, IGetMatchDetails scraperApi, IGlobalSettingsClient globalSettingsClient, IMessageSession session, ILogger<LineupState> logger)
     {
         _fixtureClient = fixtureClient;
         _scraperApi = scraperApi;
+        _globalSettingsClient = globalSettingsClient;
         _session = session;
         _logger = logger;
         _matchDetails = new Dictionary<int, MatchDetails>();
+        _oldFixtures = new List<Fixture>();
     }
 
     public async Task Reset(int gw)
     {
         _matchDetails.Clear();
-        ICollection<Fixture> fixtures;
         try
         {
-            fixtures = await _fixtureClient.GetFixturesByGameweek(gw);
+            _oldFixtures = await _fixtureClient.GetFixturesByGameweek(gw);
         }
-        catch (HttpRequestException hre) when (LogError(hre))
+        catch (Exception hre) when (LogError(hre))
         {
             return;
         }
 
-        foreach (var fixture in fixtures)
+        foreach (var fixture in _oldFixtures)
         {
             var lineups = await _scraperApi.GetMatchDetails(fixture.PulseId);
             if (lineups != null)
@@ -59,8 +63,47 @@ internal class LineupState
 
     public async Task Refresh(int gw)
     {
-        var fixtures = await _fixtureClient.GetFixturesByGameweek(gw);
+        ICollection<Fixture> updatedFixtures;
+        try
+        {
+            updatedFixtures = await _fixtureClient.GetFixturesByGameweek(gw);
 
+        }
+        catch (Exception hre) when (LogError(hre))
+        {
+            return;
+        }
+
+        await CheckForLineups(updatedFixtures);
+        await CheckForRemovedFixtures(updatedFixtures, gw);
+        _oldFixtures = updatedFixtures;
+    }
+
+    private async Task CheckForRemovedFixtures(ICollection<Fixture> updatedFixtures, int gw)
+    {
+        foreach (var fixture in _oldFixtures)
+        {
+            try
+            {
+                var isFixtureRemoved = updatedFixtures.All(f => f.Id != fixture.Id);
+                if (isFixtureRemoved)
+                {
+                    var settings = await _globalSettingsClient.GetGlobalSettings();
+                    var teams = settings.Teams;
+                    var homeTeam = teams.First(t => t.Id == fixture.HomeTeamId);
+                    var awayTeam = teams.First(t => t.Id == fixture.AwayTeamId);
+                    var removedFixture = new RemovedFixture(fixture.Id, homeTeam.ShortName, awayTeam.ShortName);
+                    await _session.Publish(new FixtureRemovedFromGameweek(gw, removedFixture));
+                }
+            }
+            catch (Exception e) when (LogError(e))
+            {
+            }
+        }
+    }
+
+    private async Task CheckForLineups(ICollection<Fixture> fixtures)
+    {
         foreach (var fixture in fixtures)
         {
             try
@@ -82,9 +125,9 @@ internal class LineupState
                 }
                 else
                 {
-                    _logger.LogWarning("Could not do match diff matchdetails for {PulseId}", new {fixture.PulseId});
-                    _logger.LogInformation($"Contains({fixture.PulseId}): {_matchDetails.ContainsKey(fixture.PulseId)}");
-                    _logger.LogInformation($"Details for ({fixture.PulseId})? : {updatedMatchDetails != null}");
+                    _logger.LogWarning("Could not do match diff matchdetails for {PulseId}", new { fixture.PulseId });
+                    _logger.LogDebug($"Contains({fixture.PulseId}): {_matchDetails.ContainsKey(fixture.PulseId)}");
+                    _logger.LogDebug($"Details for ({fixture.PulseId})? : {updatedMatchDetails != null}");
                 }
 
                 if (updatedMatchDetails != null)
@@ -92,16 +135,23 @@ internal class LineupState
                     _matchDetails[fixture.PulseId] = updatedMatchDetails;
                 }
             }
-            catch (Exception e)
+            catch (Exception e) when (LogError(e))
             {
-                _logger.LogError(e, e.Message);
             }
         }
     }
 
-    private bool LogError(HttpRequestException hre)
+    private bool LogError(Exception e)
     {
-        _logger.LogWarning("Game is updating ({StatusCode})", hre.StatusCode);
-        return hre.StatusCode == HttpStatusCode.ServiceUnavailable;
+        if (e is HttpRequestException { StatusCode: HttpStatusCode.ServiceUnavailable })
+        {
+            _logger.LogWarning("Game is updating");
+        }
+        else
+        {
+            _logger.LogError(e, e.Message);
+        }
+
+        return true;
     }
 }

--- a/src/Fpl.EventPublishers/States/LineupState.cs
+++ b/src/Fpl.EventPublishers/States/LineupState.cs
@@ -37,7 +37,7 @@ internal class LineupState
         {
             _currentFixtures = await _fixtureClient.GetFixturesByGameweek(gw);
         }
-        catch (Exception hre) when (LogError(hre))
+        catch (Exception e) when (LogError(e))
         {
             return;
         }
@@ -69,7 +69,7 @@ internal class LineupState
             updatedFixtures = await _fixtureClient.GetFixturesByGameweek(gw);
 
         }
-        catch (Exception hre) when (LogError(hre))
+        catch (Exception e) when (LogError(e))
         {
             return;
         }

--- a/src/Fpl.EventPublishers/States/MatchDayStatusMonitor.cs
+++ b/src/Fpl.EventPublishers/States/MatchDayStatusMonitor.cs
@@ -28,7 +28,7 @@ public class MatchDayStatusMonitor
         {
             fetched = await _eventStatusClient.GetEventStatus();
         }
-        catch (HttpRequestException hre) when (LogError(hre))
+        catch (Exception e) when (LogError(e))
         {
             return;
         }
@@ -69,10 +69,18 @@ public class MatchDayStatusMonitor
         _storedCurrent = fetched;
     }
 
-    private bool LogError(HttpRequestException hre)
+    private bool LogError(Exception e)
     {
-        _logger.LogWarning("Game is updating ({StatusCode})", hre.StatusCode);
-        return hre.StatusCode == HttpStatusCode.ServiceUnavailable;
+        if (e is HttpRequestException { StatusCode: HttpStatusCode.ServiceUnavailable })
+        {
+            _logger.LogWarning("Game is updating");
+        }
+        else
+        {
+            _logger.LogError(e, e.Message);
+        }
+
+        return true;
     }
 
     private static MatchdayBonusPointsAdded GetBonusAdded(EventStatusResponse fetched, EventStatusResponse current)

--- a/src/Fpl.EventPublishers/States/NearDeadLineMonitor.cs
+++ b/src/Fpl.EventPublishers/States/NearDeadLineMonitor.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using Fpl.Client.Abstractions;
 using Fpl.Client.Models;
+using Fpl.EventPublishers.Events;
+using Fpl.EventPublishers.Extensions;
 using Fpl.EventPublishers.Helpers;
 using FplBot.Messaging.Contracts.Events.v1;
 using Microsoft.Extensions.Logging;

--- a/src/Fpl.EventPublishers/States/NearDeadLineMonitor.cs
+++ b/src/Fpl.EventPublishers/States/NearDeadLineMonitor.cs
@@ -52,9 +52,17 @@ internal class NearDeadLineMonitor
         }
     }
 
-    private bool LogError(HttpRequestException hre)
+    private bool LogError(Exception e)
     {
-        _logger.LogWarning("Game is updating ({StatusCode})", hre.StatusCode);
-        return hre.StatusCode == HttpStatusCode.ServiceUnavailable;
+        if (e is HttpRequestException { StatusCode: HttpStatusCode.ServiceUnavailable })
+        {
+            _logger.LogWarning("Game is updating");
+        }
+        else
+        {
+            _logger.LogError(e, e.Message);
+        }
+
+        return true;
     }
 }

--- a/src/Fpl.EventPublishers/States/State.cs
+++ b/src/Fpl.EventPublishers/States/State.cs
@@ -1,5 +1,6 @@
 using Fpl.Client.Abstractions;
 using Fpl.Client.Models;
+using Fpl.EventPublishers.Extensions;
 using Fpl.EventPublishers.Models.Mappers;
 using FplBot.Messaging.Contracts.Events.v1;
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,7 @@ internal class State
 
     public async Task Reset(int newGameweek)
     {
+        using var scope = _logger.AddContext("StateInit");
         _logger.LogInformation($"Running reset for gw {newGameweek}");
         _currentGameweekFixtures = await _fixtureClient.GetFixturesByGameweek(newGameweek);
         var settings = await _settingsClient.GetGlobalSettings();
@@ -41,6 +43,7 @@ internal class State
 
     public async Task Refresh(int currentGameweek)
     {
+        using var scope = _logger.AddContext("StateRefresh");
         _logger.LogInformation($"Refreshing {currentGameweek}");
         var latest = await _fixtureClient.GetFixturesByGameweek(currentGameweek);
         var fixtureEvents = LiveEventsExtractor.GetUpdatedFixtureEvents(latest, _currentGameweekFixtures, _players, _teams);

--- a/src/FplBot.Data/Discord/EventSubscription.cs
+++ b/src/FplBot.Data/Discord/EventSubscription.cs
@@ -17,5 +17,5 @@ public enum EventSubscription
     Deadlines,
     Lineups,
     NewPlayers,
-    FixtureRemoved
+    FixtureRemovedFromGameweek
 }

--- a/src/FplBot.Data/Discord/EventSubscription.cs
+++ b/src/FplBot.Data/Discord/EventSubscription.cs
@@ -16,5 +16,6 @@ public enum EventSubscription
     InjuryUpdates,
     Deadlines,
     Lineups,
-    NewPlayers
+    NewPlayers,
+    FixtureRemoved
 }

--- a/src/FplBot.Data/Slack/EventSubscription.cs
+++ b/src/FplBot.Data/Slack/EventSubscription.cs
@@ -16,5 +16,6 @@ public enum EventSubscription
     InjuryUpdates,
     Deadlines,
     Lineups,
-    NewPlayers
+    NewPlayers,
+    FixtureRemovedFromGameweek
 }

--- a/src/FplBot.EventHandlers.Discord/FixtureRemovedFromGameweekHandler.cs
+++ b/src/FplBot.EventHandlers.Discord/FixtureRemovedFromGameweekHandler.cs
@@ -1,3 +1,4 @@
+using Fpl.Client.Models;
 using FplBot.Data.Discord;
 using FplBot.EventHandlers.Discord.Helpers;
 using FplBot.Messaging.Contracts.Commands.v1;
@@ -9,14 +10,17 @@ namespace FplBot.EventHandlers.Discord;
 public class FixtureRemovedFromGameweekHandler : IHandleMessages<FixtureRemovedFromGameweek>
 {
     private readonly IGuildRepository _guildRepo;
+    private readonly ILogger<FixtureRemovedFromGameweekHandler> _logger;
 
-    public FixtureRemovedFromGameweekHandler(IGuildRepository guildRepo)
+    public FixtureRemovedFromGameweekHandler(IGuildRepository guildRepo, ILogger<FixtureRemovedFromGameweekHandler> logger)
     {
         _guildRepo = guildRepo;
+        _logger = logger;
     }
 
     public async Task Handle(FixtureRemovedFromGameweek message, IMessageHandlerContext context)
     {
+        _logger.LogInformation("Fixture removed from gameweek {Message}", message);
         var subs = await _guildRepo.GetAllGuildSubscriptions();
 
         foreach (var sub in subs)
@@ -28,9 +32,9 @@ public class FixtureRemovedFromGameweekHandler : IHandleMessages<FixtureRemovedF
                 options.RouteToThisEndpoint();
                 var formattedMsg = new PublishRichToGuildChannel(sub.GuildId,
                     sub.ChannelId,
-                    $"{message.RemovedFixture.HomeTeamShortName}-{message.RemovedFixture.AwayTeamShortName}",
-                    $"Fixture has been removed from gameweek {message.Gameweek}");
-                await context.Send(formattedMsg);
+                    $"{message.RemovedFixture.Home.Name}-{message.RemovedFixture.Away.Name}",
+                    $"❌ Fixture has been removed from gameweek {message.Gameweek}!");
+                await context.Send(formattedMsg, options);
             }
         }
     }

--- a/src/FplBot.EventHandlers.Discord/FixtureRemovedFromGameweekHandler.cs
+++ b/src/FplBot.EventHandlers.Discord/FixtureRemovedFromGameweekHandler.cs
@@ -1,4 +1,3 @@
-using Fpl.Client.Models;
 using FplBot.Data.Discord;
 using FplBot.EventHandlers.Discord.Helpers;
 using FplBot.Messaging.Contracts.Commands.v1;
@@ -32,8 +31,9 @@ public class FixtureRemovedFromGameweekHandler : IHandleMessages<FixtureRemovedF
                 options.RouteToThisEndpoint();
                 var formattedMsg = new PublishRichToGuildChannel(sub.GuildId,
                     sub.ChannelId,
-                    $"{message.RemovedFixture.Home.Name}-{message.RemovedFixture.Away.Name}",
-                    $"❌ Fixture has been removed from gameweek {message.Gameweek}!");
+                    $"❌ Fixture off!",
+                    $"{message.RemovedFixture.Home.Name}-{message.RemovedFixture.Away.Name}" +
+                    $" has been removed from gameweek {message.Gameweek}!");
                 await context.Send(formattedMsg, options);
             }
         }

--- a/src/FplBot.EventHandlers.Discord/FixtureRemovedFromGameweekHandler.cs
+++ b/src/FplBot.EventHandlers.Discord/FixtureRemovedFromGameweekHandler.cs
@@ -25,7 +25,7 @@ public class FixtureRemovedFromGameweekHandler : IHandleMessages<FixtureRemovedF
 
         foreach (var sub in subs)
         {
-            if (sub.Subscriptions.ContainsSubscriptionFor(EventSubscription.FixtureRemoved))
+            if (sub.Subscriptions.ContainsSubscriptionFor(EventSubscription.FixtureRemovedFromGameweek))
             {
                 var options = new SendOptions();
                 options.RequireImmediateDispatch();

--- a/src/FplBot.EventHandlers.Discord/FixtureRemovedFromGameweekHandler.cs
+++ b/src/FplBot.EventHandlers.Discord/FixtureRemovedFromGameweekHandler.cs
@@ -1,0 +1,37 @@
+using FplBot.Data.Discord;
+using FplBot.EventHandlers.Discord.Helpers;
+using FplBot.Messaging.Contracts.Commands.v1;
+using FplBot.Messaging.Contracts.Events.v1;
+using NServiceBus;
+
+namespace FplBot.EventHandlers.Discord;
+
+public class FixtureRemovedFromGameweekHandler : IHandleMessages<FixtureRemovedFromGameweek>
+{
+    private readonly IGuildRepository _guildRepo;
+
+    public FixtureRemovedFromGameweekHandler(IGuildRepository guildRepo)
+    {
+        _guildRepo = guildRepo;
+    }
+
+    public async Task Handle(FixtureRemovedFromGameweek message, IMessageHandlerContext context)
+    {
+        var subs = await _guildRepo.GetAllGuildSubscriptions();
+
+        foreach (var sub in subs)
+        {
+            if (sub.Subscriptions.ContainsSubscriptionFor(EventSubscription.FixtureRemoved))
+            {
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                var formattedMsg = new PublishRichToGuildChannel(sub.GuildId,
+                    sub.ChannelId,
+                    $"{message.RemovedFixture.HomeTeamShortName}-{message.RemovedFixture.AwayTeamShortName}",
+                    $"Fixture has been removed from gameweek {message.Gameweek}");
+                await context.Send(formattedMsg);
+            }
+        }
+    }
+}

--- a/src/FplBot.EventHandlers.Discord/PublishToGuildHandler.cs
+++ b/src/FplBot.EventHandlers.Discord/PublishToGuildHandler.cs
@@ -33,16 +33,16 @@ public class PublishToGuildHandler :
 
     public async Task Handle(PublishRichToGuildChannel message, IMessageHandlerContext context)
     {
-        var desc = message.Description;
+        int? color = null;
 
         if (_env.IsDevelopment())
         {
-            desc = $"[{Environment.MachineName}]\n{message.Description}";
+            color = 14177041;
         }
 
         try
         {
-            await _discordClient.ChannelMessagePost(message.ChannelId, new DiscordClient.RichEmbed(message.Title, desc));
+            await _discordClient.ChannelMessagePost(message.ChannelId, new DiscordClient.RichEmbed(message.Title, message.Description, color));
         }
         catch (HttpRequestException hre) when (hre.StatusCode == HttpStatusCode.Forbidden)
         {

--- a/src/FplBot.EventHandlers.Slack/FixtureRemovedFromGameweekHandler.cs
+++ b/src/FplBot.EventHandlers.Slack/FixtureRemovedFromGameweekHandler.cs
@@ -1,0 +1,34 @@
+using FplBot.Data.Slack;
+using FplBot.EventHandlers.Slack.Helpers;
+using FplBot.Messaging.Contracts.Commands.v1;
+using FplBot.Messaging.Contracts.Events.v1;
+using NServiceBus;
+
+namespace FplBot.EventHandlers.Slack;
+
+public class FixtureRemovedFromGameweekHandler : IHandleMessages<FixtureRemovedFromGameweek>
+{
+    private readonly ISlackTeamRepository _teamRepo;
+
+    public FixtureRemovedFromGameweekHandler(ISlackTeamRepository teamRepo)
+    {
+        _teamRepo = teamRepo;
+    }
+
+    public async Task Handle(FixtureRemovedFromGameweek message, IMessageHandlerContext context)
+    {
+        var teams = await _teamRepo.GetAllTeams();
+        foreach (var team in teams)
+        {
+            if (team.Subscriptions.ContainsSubscriptionFor(EventSubscription.FixtureAssists))
+            {
+                var fixture = $"{message.RemovedFixture.Home.Name}-{message.RemovedFixture.Away.Name}";
+                var msg = $"❌ *Fixture off!*\n {fixture} has been removed from gameweek {message.Gameweek}!";
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                options.RouteToThisEndpoint();
+                await context.Send(new PublishToSlack(team.TeamId, team.FplBotSlackChannel, msg), options);
+            }
+        }
+    }
+}

--- a/src/FplBot.EventHandlers.Slack/FixtureRemovedFromGameweekHandler.cs
+++ b/src/FplBot.EventHandlers.Slack/FixtureRemovedFromGameweekHandler.cs
@@ -9,14 +9,19 @@ namespace FplBot.EventHandlers.Slack;
 public class FixtureRemovedFromGameweekHandler : IHandleMessages<FixtureRemovedFromGameweek>
 {
     private readonly ISlackTeamRepository _teamRepo;
+    private readonly ILogger<FixtureRemovedFromGameweekHandler> _logger;
 
-    public FixtureRemovedFromGameweekHandler(ISlackTeamRepository teamRepo)
+
+    public FixtureRemovedFromGameweekHandler(ISlackTeamRepository teamRepo, ILogger<FixtureRemovedFromGameweekHandler> logger)
     {
         _teamRepo = teamRepo;
+        _logger = logger;
     }
 
     public async Task Handle(FixtureRemovedFromGameweek message, IMessageHandlerContext context)
     {
+        _logger.LogInformation("Fixture removed from gameweek {Message}", message);
+
         var teams = await _teamRepo.GetAllTeams();
         foreach (var team in teams)
         {

--- a/src/FplBot.Messaging.Contracts/Events/v1/FixtureRemovedFromGameweek.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/FixtureRemovedFromGameweek.cs
@@ -2,6 +2,7 @@ using NServiceBus;
 
 namespace FplBot.Messaging.Contracts.Events.v1;
 
+[TimeToBeReceived("00:30:00")]
 public record FixtureRemovedFromGameweek(int Gameweek, RemovedFixture RemovedFixture) : IEvent;
 
 public record RemovedFixture(int Id, RemovedTeam Home, RemovedTeam Away);

--- a/src/FplBot.Messaging.Contracts/Events/v1/FixtureRemovedFromGameweek.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/FixtureRemovedFromGameweek.cs
@@ -1,0 +1,7 @@
+using NServiceBus;
+
+namespace FplBot.Messaging.Contracts.Events.v1;
+
+public record FixtureRemovedFromGameweek(int Gameweek, RemovedFixture RemovedFixture) : IEvent;
+
+public record RemovedFixture(int Id, string HomeTeamShortName, string AwayTeamShortName);

--- a/src/FplBot.Messaging.Contracts/Events/v1/FixtureRemovedFromGameweek.cs
+++ b/src/FplBot.Messaging.Contracts/Events/v1/FixtureRemovedFromGameweek.cs
@@ -4,4 +4,6 @@ namespace FplBot.Messaging.Contracts.Events.v1;
 
 public record FixtureRemovedFromGameweek(int Gameweek, RemovedFixture RemovedFixture) : IEvent;
 
-public record RemovedFixture(int Id, string HomeTeamShortName, string AwayTeamShortName);
+public record RemovedFixture(int Id, RemovedTeam Home, RemovedTeam Away);
+
+public record RemovedTeam(int Id, string Name, string ShortName);

--- a/src/FplBot.Tests/MatchStatusTests.cs
+++ b/src/FplBot.Tests/MatchStatusTests.cs
@@ -70,7 +70,7 @@ public class MatchStatusTests
         Assert.IsType<FixtureRemovedFromGameweek>(message);
         var fixtureRemovedFromGameweekEvent = ((FixtureRemovedFromGameweek)message);
         Assert.Equal(1, fixtureRemovedFromGameweekEvent.Gameweek);
-        Assert.Equal(new RemovedFixture(2, "HOM", "AWA"), fixtureRemovedFromGameweekEvent.RemovedFixture);
+        Assert.Equal(new RemovedFixture(2, new(10,"HomeTeam","HOM"), new(20, "AwAyTeam", "AWA")), fixtureRemovedFromGameweekEvent.RemovedFixture);
     }
 
     private LineupState CreateNewLineupScenario()

--- a/src/FplBot.WebApi/Controllers/DebugController.cs
+++ b/src/FplBot.WebApi/Controllers/DebugController.cs
@@ -22,7 +22,8 @@ public class DebugController
     {
         if (!_env.IsProduction())
         {
-            await _session.Publish(FixtureEvents(StatType.GoalsScored, removed));
+            var message = FixtureEvents(StatType.GoalsScored, removed);
+            await _session.Publish(message);
             // await _session.Publish(FixtureEvents(StatType.Assists, removed));
             // await _session.Publish(FixtureEvents(StatType.OwnGoals, removed));
             // await _session.Publish(FixtureEvents(StatType.PenaltiesMissed, removed));
@@ -31,11 +32,24 @@ public class DebugController
             // await _session.Publish(FixtureEvents(StatType.YellowCards, removed));
             // await _session.Publish(FixtureEvents(StatType.Saves, removed));
             // await _session.Publish(FixtureEvents(StatType.Bonus, removed));
-            return new OkResult();
+            return new AcceptedResult("", message);
         }
 
         return new UnauthorizedResult();
 
+    }
+
+    [HttpGet("removedfixture")]
+    public async Task<IActionResult> RemovedFixture(bool removed = false)
+    {
+        if (!_env.IsProduction())
+        {
+            var removedFixture = new RemovedFixture(1, new(1, "Arsenal", "ARS"), new(2, "Chelsea", "CHE"));
+            var message = new FixtureRemovedFromGameweek(1337, removedFixture);
+            await _session.Publish(message);
+            return new AcceptedResult("", message);
+        }
+        return new UnauthorizedResult();
     }
 
     private static FixtureEventsOccured FixtureEvents(StatType type, bool isRemoved)

--- a/src/ext/Discord.Net.HttpClients/DiscordClient.cs
+++ b/src/ext/Discord.Net.HttpClients/DiscordClient.cs
@@ -38,7 +38,7 @@ namespace Discord.Net.HttpClients
             res.EnsureSuccessStatusCode();
         }
 
-        public record RichEmbed(string Title, string Description);
+        public record RichEmbed(string Title, string Description, int? Color = null);
 
         public async Task ChannelMessagePost(string channelId, RichEmbed embed)
         {
@@ -51,7 +51,7 @@ namespace Discord.Net.HttpClients
                         type = "rich",
                         title = embed.Title,
                         description = embed.Description,
-                        color = 3604540
+                        color = embed.Color ?? 3604540
                     }
                 }
             });


### PR DESCRIPTION
Adds new notifications on `FixtureRemovedFromGameweek` events ( fixture is removed from a gameweek).

<img width=300 src=https://user-images.githubusercontent.com/206726/146785174-ecf6adfb-70eb-4452-b896-7aa53cee8888.png>
<img width=300 src=https://user-images.githubusercontent.com/206726/146784751-1d912f5b-013a-4964-b45c-cbb2f1b91df7.png>

TODO:

- [x] Make sure we only diff fixtures from same gw. Seems like it diffs current + next at init
- [x] Add TTL on event