### PR TITLE
Bugfix: Ignores required SSL reqs w/Redis 7

### DIFF
--- a/src/Fpl.EventPublishers.Console/Fpl.EventPublishers.Console.csproj
+++ b/src/Fpl.EventPublishers.Console/Fpl.EventPublishers.Console.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.2.50" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.116" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />

--- a/src/Fpl.Search.CommandLine/Program.cs
+++ b/src/Fpl.Search.CommandLine/Program.cs
@@ -2,6 +2,7 @@
 using System.CommandLine.Builder;
 using System.CommandLine.Hosting;
 using System.CommandLine.Parsing;
+using System.Net.Security;
 using Fpl.Search.Data;
 using Fpl.SearchConsole;
 using Fpl.SearchConsole.Commands.Definitions;
@@ -38,11 +39,14 @@ IHostBuilder ConfigureHost(string[] strings)
             {
                 ClientName = opts.GetRedisUsername,
                 Password = opts.GetRedisPassword,
-                EndPoints = {opts.GetRedisServerHostAndPort}
+                EndPoints = {opts.GetRedisServerHostAndPort},
+                SslClientAuthenticationOptions = s => new SslClientAuthenticationOptions
+                {
+                    TargetHost = opts.GetHost,
+                    RemoteCertificateValidationCallback = (h, a, c, k) => true,
+                }
             };
             var conn =  ConnectionMultiplexer.Connect(options);
             services.AddSearchConsole(ctx.Configuration, conn);
         });
 }
-
-

--- a/src/Fpl.Search.Indexer.Console/HerokuRedisConfigParser.cs
+++ b/src/Fpl.Search.Indexer.Console/HerokuRedisConfigParser.cs
@@ -1,3 +1,4 @@
+using System.Net.Security;
 using StackExchange.Redis;
 
 public static class HerokuRedisConfigParser
@@ -9,7 +10,13 @@ public static class HerokuRedisConfigParser
         {
             ClientName = GetRedisUsername(uri),
             Password = GetRedisPassword(uri),
-            EndPoints = { GetRedisServerHostAndPort(redisUri)}
+            EndPoints = { GetRedisServerHostAndPort(redisUri)},
+            Ssl = true,
+            SslClientAuthenticationOptions = s => new SslClientAuthenticationOptions
+            {
+                TargetHost = GetHost(redisUri),
+                RemoteCertificateValidationCallback = (h, a, c, k) => true,
+            }
         };
     }
 
@@ -18,4 +25,7 @@ public static class HerokuRedisConfigParser
     private static string GetRedisUsername(Uri redisUri) => redisUri.UserInfo.Split(":")[0];
 
     private static string GetRedisServerHostAndPort(string redisUri) => redisUri.Split("@")[1];
+
+    private static string GetHost(string redisUri) => redisUri.Split(":")[0];
+
 }

--- a/src/Fpl.Search/Data/SearchRedisOptions.cs
+++ b/src/Fpl.Search/Data/SearchRedisOptions.cs
@@ -9,6 +9,8 @@ public class SearchRedisOptions
 
     public string GetRedisServerHostAndPort => REDIS_URL.Split("@")[1];
 
+    public string GetHost => GetRedisServerHostAndPort.Split(":")[0];
+
     private Uri _uri;
 
     private Uri RedisUri()

--- a/src/FplBot.Data/FplBot.Data.csproj
+++ b/src/FplBot.Data/FplBot.Data.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.2.50" />
-  </ItemGroup>  
+    <PackageReference Include="StackExchange.Redis" Version="2.6.116" />
+  </ItemGroup>
 
 </Project>

--- a/src/FplBot.Data/Slack/RedisOptions.cs
+++ b/src/FplBot.Data/Slack/RedisOptions.cs
@@ -9,6 +9,8 @@ public class SlackRedisOptions
 
     public string GetRedisServerHostAndPort => REDIS_URL.Split("@")[1];
 
+    public string GetHost => GetRedisServerHostAndPort.Split(":")[0];
+
     private Uri _uri;
 
     private Uri RedisUri()

--- a/src/FplBot.VerifiedEntries/Data/VerifiedRedisOptions.cs
+++ b/src/FplBot.VerifiedEntries/Data/VerifiedRedisOptions.cs
@@ -9,6 +9,8 @@ public class VerifiedRedisOptions
 
     public string GetRedisServerHostAndPort => REDIS_URL.Split("@")[1];
 
+    public string GetHost => GetRedisServerHostAndPort.Split(":")[0];
+
     private Uri _uri;
 
     private Uri RedisUri()

--- a/src/FplBot.VerifiedEntries/FplBot.VerifiedEntries.csproj
+++ b/src/FplBot.VerifiedEntries/FplBot.VerifiedEntries.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetVersion)" />
-    <PackageReference Include="StackExchange.Redis" Version="2.2.50" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.116" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FplBot.VerifiedEntries/ServiceCollectionExtensions.cs
+++ b/src/FplBot.VerifiedEntries/ServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using System.Net.Security;
+using System.Security.Authentication;
 using FplBot.VerifiedEntries;
 using FplBot.VerifiedEntries.Data;
 using FplBot.VerifiedEntries.Data.Abstractions;
@@ -25,7 +27,13 @@ public static class ServiceCollectionFplBotExtensions
             {
                 ClientName = opts.GetRedisUsername,
                 Password = opts.GetRedisPassword,
-                EndPoints = {opts.GetRedisServerHostAndPort}
+                EndPoints = { opts.GetRedisServerHostAndPort },
+                Ssl = true,
+                SslClientAuthenticationOptions = s => new SslClientAuthenticationOptions
+                {
+                    TargetHost = opts.GetHost,
+                    RemoteCertificateValidationCallback = (h, a, c, k) => true,
+                }
             };
             return ConnectionMultiplexer.Connect(options);
         });

--- a/src/FplBot.WebApi.Discord/FplBot.WebApi.Discord.csproj
+++ b/src/FplBot.WebApi.Discord/FplBot.WebApi.Discord.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.2.50"/>
+    <PackageReference Include="StackExchange.Redis" Version="2.6.116"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FplBot.WebApi.Slack/FplBot.WebApi.Slack.csproj
+++ b/src/FplBot.WebApi.Slack/FplBot.WebApi.Slack.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fastenshtein" Version="1.0.0.7"/>
-    <PackageReference Include="StackExchange.Redis" Version="2.2.50"/>
+    <PackageReference Include="StackExchange.Redis" Version="2.6.116"/>
     <PackageReference Include="Slackbot.Net.Endpoints" Version="$(SlackbotNetVersion)"/>
     <PackageReference Include="Slackbot.Net.SlackClients.Http" Version="$(SlackbotNetVersion)"/>
   </ItemGroup>

--- a/src/FplBot.WebApi.Tests/FplBot.WebApi.Tests.csproj
+++ b/src/FplBot.WebApi.Tests/FplBot.WebApi.Tests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="StackExchange.Redis" Version="2.2.50" />
+        <PackageReference Include="StackExchange.Redis" Version="2.6.116" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
           <PrivateAssets>all</PrivateAssets>

--- a/src/FplBot.WebApi.Tests/RedisIntegrationTests.cs
+++ b/src/FplBot.WebApi.Tests/RedisIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Security;
 using Fpl.Search.Data.Repositories;
 using FplBot.Data.Discord;
 using FplBot.Data.Slack;
@@ -49,7 +50,13 @@ public class RedisIntegrationTests : IDisposable
             ClientName = opts.Value.GetRedisUsername,
             Password = opts.Value.GetRedisPassword,
             EndPoints = { opts.Value.GetRedisServerHostAndPort },
-            AllowAdmin = true
+            AllowAdmin = true,
+            Ssl = true,
+            SslClientAuthenticationOptions = s => new SslClientAuthenticationOptions
+            {
+                TargetHost = opts.Value.GetHost,
+                RemoteCertificateValidationCallback = (h, a, c, k) => true,
+            }
         };
 
         var multiplexer = ConnectionMultiplexer.Connect(configurationOptions);

--- a/src/FplBot.WebApi/FplBot.WebApi.csproj
+++ b/src/FplBot.WebApi/FplBot.WebApi.csproj
@@ -6,10 +6,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>    
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.10" />
-    
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.8" />    
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />

--- a/src/FplBot.WebApi/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/FplBot.WebApi/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -1,3 +1,7 @@
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json.Serialization;
 using AspNet.Security.OAuth.Slack;
 using Discord.Net.Endpoints.Authentication;
@@ -44,7 +48,13 @@ public static class WebApplicationBuilderExtensions
         {
             ClientName = opts.GetRedisUsername,
             Password = opts.GetRedisPassword,
-            EndPoints = {opts.GetRedisServerHostAndPort}
+            EndPoints = {opts.GetRedisServerHostAndPort},
+            Ssl = true,
+            SslClientAuthenticationOptions = s => new SslClientAuthenticationOptions
+            {
+                TargetHost = opts.GetHost,
+                RemoteCertificateValidationCallback = (h, a, c, k) => true,
+            }
         };
         var conn =  ConnectionMultiplexer.Connect(options);
 


### PR DESCRIPTION
Forced update to Redis 7 from Heroku.

Fixes:
- Upgrades `StackExchange.Redis` to latest
- Ignores enforced SSL validation on Redis connections (it looks like the [recommended approach](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-node-js))