### PR TITLE
Adds redis hack to non-API components

### DIFF
--- a/src/Fpl.EventPublishers.Console/HerokuRedisConfigParser.cs
+++ b/src/Fpl.EventPublishers.Console/HerokuRedisConfigParser.cs
@@ -1,3 +1,4 @@
+using System.Net.Security;
 using StackExchange.Redis;
 
 namespace Fpl.EventPublishers.Console;
@@ -11,7 +12,13 @@ public static class HerokuRedisConfigParser
         {
             ClientName = GetRedisUsername(uri),
             Password = GetRedisPassword(uri),
-            EndPoints = { GetRedisServerHostAndPort(redisUri)}
+            EndPoints = { GetRedisServerHostAndPort(redisUri)},
+            Ssl = true,
+            SslClientAuthenticationOptions = s => new SslClientAuthenticationOptions
+            {
+                TargetHost = GetHost(redisUri),
+                RemoteCertificateValidationCallback = (h, a, c, k) => true,
+            }
         };
     }
 
@@ -20,4 +27,6 @@ public static class HerokuRedisConfigParser
     private static string GetRedisUsername(Uri redisUri) => redisUri.UserInfo.Split(":")[0];
 
     private static string GetRedisServerHostAndPort(string redisUri) => redisUri.Split("@")[1];
+
+    private static string GetHost(string redisUri) => redisUri.Split(":")[0];
 }

--- a/src/Fpl.Search.Indexer.Console/HerokuRedisConfigParser.cs
+++ b/src/Fpl.Search.Indexer.Console/HerokuRedisConfigParser.cs
@@ -27,5 +27,4 @@ public static class HerokuRedisConfigParser
     private static string GetRedisServerHostAndPort(string redisUri) => redisUri.Split("@")[1];
 
     private static string GetHost(string redisUri) => redisUri.Split(":")[0];
-
 }

--- a/src/FplBot.EventHandlers.Console/HerokuRedisConfigParser.cs
+++ b/src/FplBot.EventHandlers.Console/HerokuRedisConfigParser.cs
@@ -1,3 +1,4 @@
+using System.Net.Security;
 using StackExchange.Redis;
 
 namespace FplBot.EventHandlers.Console;
@@ -11,7 +12,13 @@ public static class HerokuRedisConfigParser
         {
             ClientName = GetRedisUsername(uri),
             Password = GetRedisPassword(uri),
-            EndPoints = { GetRedisServerHostAndPort(redisUri)}
+            EndPoints = { GetRedisServerHostAndPort(redisUri)},
+            Ssl = true,
+            SslClientAuthenticationOptions = s => new SslClientAuthenticationOptions
+            {
+                TargetHost = GetHost(redisUri),
+                RemoteCertificateValidationCallback = (h, a, c, k) => true,
+            }
         };
     }
 
@@ -20,4 +27,6 @@ public static class HerokuRedisConfigParser
     private static string GetRedisUsername(Uri redisUri) => redisUri.UserInfo.Split(":")[0];
 
     private static string GetRedisServerHostAndPort(string redisUri) => redisUri.Split("@")[1];
+
+    private static string GetHost(string redisUri) => redisUri.Split(":")[0];
 }


### PR DESCRIPTION
Last bugfix only took care of the API. This PR fixes the same issue for:

- EventPublisher
- Indexer
- EventHandler
