### PR TITLE
Bugfix: dont check for lineups after gw38

### DIFF
--- a/src/Fpl.EventPublishers/Mediators/LineupsMediator.cs
+++ b/src/Fpl.EventPublishers/Mediators/LineupsMediator.cs
@@ -52,11 +52,18 @@ internal class LineupsHandler :
         return _matchState.Refresh(notification.Gameweek.Id);
     }
 
-    public Task Handle(GameweekCurrentlyFinished notification, CancellationToken cancellationToken)
+    public async Task Handle(GameweekCurrentlyFinished notification, CancellationToken cancellationToken)
     {
         using var scope = _logger.AddContext(Tuple.Create(nameof(GameweekCurrentlyFinished), (notification.Gameweek.Id+1).ToString()));
         _logger.LogInformation("Refreshing state for finished gw {Gameweek}. Using next gw {NextGameweek}", notification.Gameweek.Id, notification.Gameweek.Id + 1);
-        return _matchState.Refresh(notification.Gameweek.Id + 1); // monitor next gameweeks matches, since current = finished
+        if (notification.Gameweek.Id < 39)
+        {
+            await _matchState.Refresh(notification.Gameweek.Id + 1); // monitor next gameweeks matches, since current = finished
+        }
+        else
+        {
+            _logger.LogInformation("Not refreshing state. Current gw is the last gw : {Gameweek}", notification.Gameweek.Id);
+        }
     }
 
     public Task Handle(CurrentlyPreseason notification, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes a small season-finished-bug, where bot would try to check for lineups in non-existing "next" gw 39 (38+1):

```
[INF] Fpl.EventPublishers.Mediators.LineupsHandler: Refreshing state for finished gw 38. Using next gw 39
[ERR] Fpl.EventPublishers.RecurringActions.GameweekLifecycleRecurringAction Sequence contains no elements
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at Fpl.EventPublishers.States.LineupState.Refresh(Int32 gw) in /app/Fpl.EventPublishers/States/LineupState.cs:line 78
   at MediatR.Mediator.PublishCore(IEnumerable`1 allHandlers, INotification notification, CancellationToken cancellationToken)
   at Fpl.EventPublishers.States.GameweekLifecycleMonitor.EveryOtherMinuteTick(CancellationToken token) in /app/Fpl.EventPublishers/States/GameweekLifecycleMonitor.cs:line 106
   at Fpl.EventPublishers.RecurringActions.GameweekLifecycleRecurringAction.Process(CancellationToken token) in /app/Fpl.EventPublishers/RecurringActions/GameweekLifecycleRecurringAction.cs:line 24
   at CronBackgroundServices.CronBackgroundService.ExecuteAsync(CancellationToken stoppingToken)
```

https://github.com/fplbot/fplbot/blob/11e673d5007e9e3c9743a39dc3954372e3f55c0a/src/Fpl.EventPublishers/Mediators/LineupsMediator.cs#L55-L60