### PR TITLE
Bugfix: standings when no entries for gw

### DIFF
--- a/src/FplBot.Formatting/Formatter.cs
+++ b/src/FplBot.Formatting/Formatter.cs
@@ -401,8 +401,13 @@ public static class Formatter
     {
         var introText = $"{gw.Name} is finished.";
         var globalAverage = (int)Math.Round((double)gw.AverageScore);
-        var leagueAverage = (int)Math.Round((double)league.Standings.Entries.Average(entry => entry.EventTotal));
-        var diff = Math.Abs(globalAverage - leagueAverage);
+
+        var leagueAvgTxt = "";
+        if (league.Standings.Entries.Any())
+        {
+            var leagueAverage = (int)Math.Round((double)league.Standings.Entries.Average(entry => entry.EventTotal));
+            leagueAvgTxt = $" Your league's average was *{leagueAverage}* points.";
+        }
 
         if (globalAverage < 40)
         {
@@ -417,7 +422,7 @@ public static class Formatter
             introText += $" The global average was *{globalAverage}* points.";
         }
 
-        introText += $" Your league's average was *{leagueAverage}* points.";
+        introText += leagueAvgTxt;
 
         return introText;
     }


### PR DESCRIPTION
Typically if league was started mid-season, there would be no entries. 

`Enumerable.Average` throws exceptions when enumerable has no elements:

```
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.Average[TSource](IEnumerable`1 source, Func`2 selector)
   at FplBot.Formatting.Formatter.FormatGameweekFinished(Gameweek gw, ClassicLeague league) in /app/FplBot.Formatting/Formatter.cs:line 420
   at FplBot.EventHandlers.Discord.GameweekFinishedHandler.Handle(PublishGameweekFinishedToGuild message, IMessageHandlerContext context) in /app/FplBot.EventHandlers.Discord/GameweekFinishedHandler.cs:line 57
```

https://github.com/fplbot/fplbot/blob/0a01ec1a01ce53dc31b6e399783e06b62bb95419/src/FplBot.Formatting/Formatter.cs#L404