### PR TITLE
Moves from stale properties to calculate fixture score from stats array

### DIFF
--- a/src/Fpl.Client/Models/Fixture.cs
+++ b/src/Fpl.Client/Models/Fixture.cs
@@ -23,7 +23,7 @@ public class Fixture
     public string FormattedDeadlineTime { get; set; }
 
     [JsonPropertyName("stats")]
-    public FixtureStat[] Stats { get; set; } = new FixtureStat[0];
+    public FixtureStat[] Stats { get; set; } = Array.Empty<FixtureStat>();
 
     [JsonPropertyName("team_h_difficulty")]
     public int HomeTeamDifficulty { get; set; }

--- a/src/Fpl.EventPublishers/Models/Mappers/LiveEventsExtractor.cs
+++ b/src/Fpl.EventPublishers/Models/Mappers/LiveEventsExtractor.cs
@@ -1,3 +1,4 @@
+using Fpl.Client;
 using Fpl.Client.Models;
 using Fpl.EventPublishers.Extensions;
 using Fpl.EventPublishers.Models.Comparers;
@@ -25,6 +26,10 @@ public class LiveEventsExtractor
                 var newFixtureStats = FixtureDiffer.DiffFixtureStats(fixture, oldFixture, players);
 
                 if (newFixtureStats.Values.Any())
+                {
+                    var goalScored = fixture.Stats.FirstOrDefault(c => c.Identifier == FplConstants.StatIdentifiers.GoalsScored);
+                    var homeTeamScore = goalScored?.HomeStats?.Sum(s => s.Value) ?? 0;
+                    var awayTeamScore = goalScored?.AwayStats?.Sum(s => s.Value) ?? 0;
                     return new FixtureEvents
                     (
                         new FixtureScore(
@@ -32,13 +37,13 @@ public class LiveEventsExtractor
                             new FixtureTeam(homeTeam.Id, homeTeam.Name, homeTeam.ShortName),
                             new FixtureTeam(awayTeam.Id, awayTeam.Name, awayTeam.ShortName),
                             fixture.Minutes,
-                            fixture.HomeTeamScore,
-                            fixture.AwayTeamScore
+                            homeTeamScore,
+                            awayTeamScore
                         ),
                         newFixtureStats
                     );
-                else
-                    return null;
+                }
+                return null;
             }
 
             return null;

--- a/src/FplBot.Tests/GetUpdatedFixtureEventsTests.cs
+++ b/src/FplBot.Tests/GetUpdatedFixtureEventsTests.cs
@@ -32,6 +32,49 @@ public class GetUpdatedFixtureEventsTests
         Assert.Equal(123, awayGoalEvent.StatMap[StatType.GoalsScored].First().Player.Id);
         Assert.Equal(TeamType.Away, awayGoalEvent.StatMap[StatType.GoalsScored].First().Team);
         Assert.Equal(72, awayGoalEvent.FixtureScore.Minutes);
+        Assert.Equal(0, awayGoalEvent.FixtureScore.HomeTeamScore);
+        Assert.Equal(1, awayGoalEvent.FixtureScore.AwayTeamScore);
+    }
+
+    [Fact]
+    public static void When_DifferentScorers_ReturnsCorrectScore()
+    {
+        var current = new List<Fixture>
+        {
+            TestBuilder.NoGoals(fixtureCode:1)
+        };
+
+        var updatedFixture = TestBuilder.NoGoals(1);
+        updatedFixture.AddAwayGoal();
+        updatedFixture.AddAwayGoal();
+        updatedFixture.AddAwayGoal();
+
+        var latest = new List<Fixture>
+        {
+            updatedFixture
+        };
+
+        var events = LiveEventsExtractor.GetUpdatedFixtureEvents(latest, current, new List<Player> { TestBuilder.Player()}, new List<Team> { TestBuilder.HomeTeam(), TestBuilder.AwayTeam()});
+        var awayGoalEvent = events.First();
+        Assert.Equal(0, awayGoalEvent.FixtureScore.HomeTeamScore);
+        Assert.Equal(3, awayGoalEvent.FixtureScore.AwayTeamScore);
+    }
+
+    [Fact]
+    public static void When_NoStats_ReturnsEmpty()
+    {
+        var current = new List<Fixture>
+        {
+            TestBuilder.NoGoals(fixtureCode:1)
+        };
+
+        var latest = new List<Fixture>
+        {
+            TestBuilder.NoGoals(fixtureCode:1)
+        };
+
+        var events = LiveEventsExtractor.GetUpdatedFixtureEvents(latest, current, new List<Player> { TestBuilder.Player()}, new List<Team> { TestBuilder.HomeTeam(), TestBuilder.AwayTeam()});
+        Assert.Empty(events);
     }
 
     private static void AssertEmpty(ICollection<Fixture> latest, ICollection<Fixture> current)

--- a/src/FplBot.Tests/Helpers/TestBuilder.cs
+++ b/src/FplBot.Tests/Helpers/TestBuilder.cs
@@ -57,13 +57,43 @@ public static class TestBuilder
             Started = true,
             Stats = new[]
             {
-                AwayTeamLeadingBy(goals)
+                AddGoalsScored(goals, PlayerId)
             },
             HomeTeamScore = 0,
             AwayTeamScore = goals,
             PulseId = fixtureCode,
             Minutes = minutes.HasValue ? minutes.Value : 30
         };
+    }
+
+    public static Fixture AddAwayGoal(this Fixture fixture, int numGoals = 1)
+    {
+        var goalScoredStats = fixture.Stats.FirstOrDefault(c => c.Identifier == "goals_scored");
+
+        var awayGoal = new FixtureStatValue
+        {
+            Element = PlayerId,
+            Value = numGoals
+        };
+
+        if (goalScoredStats is null)
+        {
+            goalScoredStats = new FixtureStat
+            {
+                Identifier = "goals_scored",
+                HomeStats = Array.Empty<FixtureStatValue>(),
+                AwayStats = new[] { awayGoal }
+            };
+            var updatedStats = fixture.Stats.Append(goalScoredStats);
+            fixture.Stats = updatedStats.ToArray();
+        }
+        else
+        {
+            var updatedAwayStats = goalScoredStats.AwayStats.Append(awayGoal);
+            goalScoredStats.AwayStats = updatedAwayStats.ToArray();
+        }
+
+        return fixture;
     }
 
     public static Fixture FinishedProvisional(this Fixture fixture)
@@ -144,7 +174,7 @@ public static class TestBuilder
         };
     }
 
-    private static FixtureStat AwayTeamLeadingBy(int goals)
+    private static FixtureStat AddGoalsScored(int goals, int playerId)
     {
         return new FixtureStat
         {
@@ -157,7 +187,7 @@ public static class TestBuilder
             {
                 new FixtureStatValue
                 {
-                    Element = PlayerId,
+                    Element = playerId,
                     Value = goals
                 }
             }


### PR DESCRIPTION
## Bugfix

Relates to [#317-Goal Score Notifications Wrong](https://github.com/fplbot/fplbot/issues/317)

![snip ghhqwbsM](https://github.com/fplbot/fplbot/assets/206726/4ff380a9-c504-4e29-8ee0-b92564521061)

`team_h_score` & `team_a_score` are often out of sync with the `goal_scored` stats. This change moves to calculate the home and away goal tally instead.

![snip VkNYSahA](https://github.com/fplbot/fplbot/assets/206726/4475b21a-2c2c-4c95-8ec0-d00f7c7006a5)

Solves #317 