### PR TITLE
🪲 Bugfix: worst entry is null sometimes

### DIFF
--- a/src/Fpl.Client/Models/ClassicLeagueStandings.cs
+++ b/src/Fpl.Client/Models/ClassicLeagueStandings.cs
@@ -12,5 +12,5 @@ public class ClassicLeagueStandings
     public int Number { get; set; }
 
     [JsonPropertyName("results")]
-    public ICollection<ClassicLeagueEntry> Entries { get; set; }
+    public ICollection<ClassicLeagueEntry> Entries { get; set; } = new List<ClassicLeagueEntry>();
 }

--- a/src/FplBot.EventHandlers.Discord/GameweekFinishedHandler.cs
+++ b/src/FplBot.EventHandlers.Discord/GameweekFinishedHandler.cs
@@ -63,8 +63,12 @@ public class GameweekFinishedHandler : IHandleMessages<GameweekFinished>,
                     new ("ℹ️ Gameweek finished!",intro),
                     new ("ℹ️ Standings", standings),
                     new ("ℹ️ Top 3", topThree),
-                    new ("ℹ️ Lantern beige", worst)
                 });
+
+                if (worst is not null)
+                {
+                    messages.Add(new("ℹ️ Lantern beige", worst));
+                }
                 var i = 0;
                 foreach (var richMessage in messages)
                 {

--- a/src/FplBot.EventHandlers.Slack/GameweekFinishedHandler.cs
+++ b/src/FplBot.EventHandlers.Slack/GameweekFinishedHandler.cs
@@ -56,7 +56,13 @@ internal class GameweekFinishedHandler : IHandleMessages<GameweekFinished>, IHan
             var standings = Formatter.GetStandings(league, gw);
             var topThree = Formatter.GetTopThreeGameweekEntries(league, gw);
             var worst = Formatter.GetWorstGameweekEntry(league, gw);
-            await _publisher.PublishToWorkspace(message.WorkspaceId, message.Channel, intro, standings, topThree, worst);
+
+            var messages = new List<string> { intro, standings, topThree};
+            if (worst is not null)
+            {
+                messages.Add(worst);
+            }
+            await _publisher.PublishToWorkspace(message.WorkspaceId, message.Channel, messages.ToArray());
         }
         catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {

--- a/src/FplBot.EventHandlers.Slack/Helpers/SlackWorkSpacePublisher.cs
+++ b/src/FplBot.EventHandlers.Slack/Helpers/SlackWorkSpacePublisher.cs
@@ -32,13 +32,11 @@ public class SlackWorkSpacePublisher : ISlackWorkSpacePublisher
     {
         foreach (var msg in messages)
         {
-            var req = new ChatPostMessageRequest
+            if (msg is { Length: > 0 })
             {
-                Channel = channel,
-                Text = msg,
-                unfurl_links = "false"
-            };
-            await PublishToWorkspace(teamId, req);
+                var req = new ChatPostMessageRequest { Channel = channel, Text = msg, unfurl_links = "false" };
+                await PublishToWorkspace(teamId, req);
+            }
         }
     }
 

--- a/src/FplBot.Formatting/Formatter.cs
+++ b/src/FplBot.Formatting/Formatter.cs
@@ -71,8 +71,8 @@ public static class Formatter
 
     public static string GetWorstGameweekEntry(ClassicLeague league, Gameweek gameweek, bool includeExternalLinks = true)
     {
-        var worst = league.Standings.Entries.OrderBy(e => e.EventTotal).FirstOrDefault();
-        string entryOrEntryLink = includeExternalLinks? worst.GetEntryLink(gameweek.Id) : worst?.EntryName;
+        var worst = league.Standings.Entries.MinBy(e => e.EventTotal);
+        string entryOrEntryLink = includeExternalLinks? worst?.GetEntryLink(gameweek.Id) : worst?.EntryName;
         return worst == null ? null : $"💩 {entryOrEntryLink} only got {worst.EventTotal} points. Wow.";
     }
 


### PR DESCRIPTION
No idea why, and did not bother to investigate: 7 Slack workspaces did not have a "worst" entry in GW1. Not seen the same issue in Discord, so a bit odd. Added som null handling around Slack + formatting of standings on gameweek finished events.

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at FplBot.Formatting.ClassicLeagueEntryExtensions.GetEntryLink(ClassicLeagueEntry entry, Nullable`1 gameweek) in /app/FplBot.Formatting/ClassicLeagueEntryExtensions.cs:line 14
   at FplBot.Formatting.Formatter.GetWorstGameweekEntry(ClassicLeague league, Gameweek gameweek, Boolean includeExternalLinks) in /app/FplBot.Formatting/Formatter.cs:line 75
   at FplBot.EventHandlers.Slack.GameweekFinishedHandler.Handle(PublishStandingsToSlackWorkspace message, IMessageHandlerContext context) in /app/FplBot.EventHandlers.Slack/GameweekFinishedHandler.cs:line 65
```