### PR TITLE
Improve handling of large notifications on Discord

### DIFF
--- a/src/Fpl.Client/Models/Pick.cs
+++ b/src/Fpl.Client/Models/Pick.cs
@@ -7,9 +7,6 @@ public class Pick
     [JsonPropertyName("element")]
     public int PlayerId { get; set; }
 
-    [JsonPropertyName("element_type")]
-    public int ElementType { get; set; }
-
     [JsonPropertyName("position")]
     public int TeamPosition { get; set; }
 

--- a/src/FplBot.Formatting/ClassicLeagueEntryExtensions.cs
+++ b/src/FplBot.Formatting/ClassicLeagueEntryExtensions.cs
@@ -14,5 +14,10 @@ public static class ClassicLeagueEntryExtensions
         return Formatter.GetEntryLink(entry.Entry, entry.EntryName, gameweek);
     }
 
+    public static string GetEntryTransferLink(this ClassicLeagueEntry entry)
+    {
+        return Formatter.GetEntryTransferLink(entry.Entry);
+    }
+
 
 }

--- a/src/FplBot.Formatting/Formatter.cs
+++ b/src/FplBot.Formatting/Formatter.cs
@@ -319,6 +319,18 @@ public static class Formatter
         };
     }
 
+    public static string PositionEmoji(FplPlayerPosition position)
+    {
+        return position switch
+        {
+            FplPlayerPosition.Goalkeeper => "🧤",
+            FplPlayerPosition.Defender => "🛡",
+            FplPlayerPosition.Midfielder => "⚙️",
+            FplPlayerPosition.Forward => "⚡️️",
+            _ => "⁇"
+        };
+    }
+
     public static string FormatProvisionalFinished(FinishedFixture fixture)
     {
         var fullTimeReport = "";
@@ -553,6 +565,11 @@ public static class Formatter
     public static string GetEntryLink(int entryId, string name, int? gameweek)
     {
         return $"<https://fantasy.premierleague.com/entry/{entryId}/{GetLinkSuffix(gameweek)}|{name}>";
+    }
+
+    public static string GetEntryTransferLink(int entryId)
+    {
+        return $"https://fantasy.premierleague.com/entry/{entryId}/transfers";
     }
 
     private static string GetLinkSuffix(int? gameweek) => gameweek.HasValue ? $"event/{gameweek.Value}" : "history";

--- a/src/FplBot.Formatting/TransfersByGameWeek.cs
+++ b/src/FplBot.Formatting/TransfersByGameWeek.cs
@@ -254,9 +254,26 @@ public class TransfersByGameWeek : ITransfersByGameWeek
                     var transferCostString = transferCost > 0 ? $" (-{transferCost} pts)" : "";
                     sb.Append($"{entryLinkOrName} transferred{transferCostString}:\n");
                 }
-                foreach (var entryTransfer in transfers)
+
+                if (wildcardPlayed || freeHitPlayed)
                 {
-                    sb.Append($"   ▪️{entryTransfer.PlayerTransferredOut} ({Formatter.FormatCurrency(entryTransfer.SoldFor)}) ➡️ {entryTransfer.PlayerTransferredIn} ({Formatter.FormatCurrency(entryTransfer.BoughtFor)})\n");
+                    sb.Append($"   Made use of {transfers.Length} transfers. Final 11:\n");
+                    var firstEleven = picks.Picks.OrderBy(p => p.TeamPosition).Take(11);
+                    var starters = firstEleven.Select(first11pick => players.SingleOrDefault(x => x.Id == first11pick.PlayerId)).ToList();
+                    foreach (var playerGroup in starters.GroupBy(p => p.Position))
+                    {
+                        var playersInPos = string.Join("  ", playerGroup.Select(p => p.WebName));
+                        var player = playerGroup.First();
+                        var pos = Formatter.PositionEmoji(player.Position);
+                        sb.Append($"      {pos} {playersInPos}\n");
+                    }
+                }
+                else
+                {
+                    foreach (var entryTransfer in transfers)
+                    {
+                        sb.Append($"   ▪️{entryTransfer.PlayerTransferredOut} ({Formatter.FormatCurrency(entryTransfer.SoldFor)}) ➡️ {entryTransfer.PlayerTransferredIn} ({Formatter.FormatCurrency(entryTransfer.BoughtFor)})\n");
+                    }
                 }
             }
             catch (Exception e)

--- a/src/FplBot.WebApi/Endpoints/Test/DebugRoute.cs
+++ b/src/FplBot.WebApi/Endpoints/Test/DebugRoute.cs
@@ -1,3 +1,4 @@
+using FplBot.WebApi.Endpoints.Test.Gameweekstart;
 using FplBot.WebApi.Endpoints.Test.Goal;
 using FplBot.WebApi.Endpoints.Test.RemovedFixtures;
 using FplBot.WebApi.Endpoints.Test.Transfer;
@@ -11,5 +12,6 @@ public static class TestEndpoints
         app.MapGet($"{baseRoute}/transfers", TestTransfer.Get);
         app.MapGet($"{baseRoute}/removedfixture", TestRemovedFixture.Get);
         app.MapGet($"{baseRoute}/goal", TestGoal.Get);
+        app.MapGet($"{baseRoute}/gameweekstart", TestGwStart.Get);
     }
 }

--- a/src/FplBot.WebApi/Endpoints/Test/Gameweekstart/TestGwStart.cs
+++ b/src/FplBot.WebApi/Endpoints/Test/Gameweekstart/TestGwStart.cs
@@ -1,0 +1,27 @@
+using FplBot.Messaging.Contracts.Commands.v1;
+using Microsoft.AspNetCore.Mvc;
+using NServiceBus;
+
+namespace FplBot.WebApi.Endpoints.Test.Gameweekstart;
+
+public static class TestGwStart
+{
+    public static async Task<IActionResult> Get(IWebHostEnvironment env, IMessageSession session)
+    {
+        if (env.IsProduction())
+            return new UnauthorizedResult();
+
+        var options = new SendOptions();
+        options.RequireImmediateDispatch();
+        options.SetDestination("FplBot.EventHandlers.Discord");
+        var cmd = new ProcessGameweekStartedForGuildChannel("893932860162064414", "897565955587186838", 4);
+        await session.Send(cmd, options);
+
+        var otheroptions = new SendOptions();
+        otheroptions.RequireImmediateDispatch();
+        otheroptions.SetDestination("FplBot.EventHandlers.Slack");
+        var cmdSlack = new ProcessGameweekStartedForSlackWorkspace("t016b9n3u7p".ToUpper(), 4);
+        await session.Send(cmdSlack, otheroptions);
+        return new AcceptedResult("", cmd);
+    }
+}

--- a/test.http
+++ b/test.http
@@ -163,4 +163,4 @@ Content-Type: application/json
 }
 
 ### test event formatting
-GET http://localhost:1337/debug/goal
+GET http://localhost:1337/debug/gameweekstart


### PR DESCRIPTION
Discord has a max-limit of 2000 chars pr chat message. In the event of large count of transfers (wildcards, free hits), the messages we send hit this limit (current chunking is not perfect). This PR chunks messages into even smaller pieces, and changes how we display the transfers when managers use wildcards/free hits:

### Changes to the _transfers_ notification:
- ♻️ _Show the number of transfers done instead of every single transfer made._
- 🆕 _Show the final eleven picks similar to the lineups._

![snip BMeuMPne@2x](https://github.com/fplbot/fplbot/assets/206726/d657a960-6f9e-4198-8960-dd5ba8ae30d5)
