### PR TITLE
Bugfix: lineups are without formation and matchposition

### DIFF
--- a/src/Fpl.EventPublishers/Models/Mappers/MatchDetailsMapper.cs
+++ b/src/Fpl.EventPublishers/Models/Mappers/MatchDetailsMapper.cs
@@ -4,7 +4,7 @@ namespace Fpl.EventPublishers.Models.Mappers;
 
 public class MatchDetailsMapper
 {
-    public static LineupReady TryMapToLineup(MatchDetails details)
+    public static LineupReady TryMapToLineup(MatchDetails details, Action<Exception> logger = null)
     {
         try
         {
@@ -30,8 +30,9 @@ public class MatchDetailsMapper
             return null;
 
         }
-        catch
+        catch(Exception e)
         {
+            logger?.Invoke(e);
             return null;
         }
     }

--- a/src/Fpl.EventPublishers/States/LineupState.cs
+++ b/src/Fpl.EventPublishers/States/LineupState.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using Fpl.Client.Abstractions;
 using Fpl.Client.Models;
 using Fpl.EventPublishers.Abstractions;
@@ -132,7 +133,7 @@ internal class LineupState
                     var lineupsConfirmed = !storedDetails.HasLineUps() && updatedMatchDetails.HasLineUps();
                     if (lineupsConfirmed)
                     {
-                        var lineups = MatchDetailsMapper.TryMapToLineup(updatedMatchDetails);
+                        var lineups = MatchDetailsMapper.TryMapToLineup(updatedMatchDetails, e => _logger.LogError(e, e.Message));
 
                         if (lineups != null)
                         {
@@ -141,6 +142,11 @@ internal class LineupState
                         else
                         {
                             _logger.LogWarning("FAILED TO PUBLISH LINEUPS FOR {PulseId}", new { fixture.PulseId });
+                            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+                            {
+                                WriteIndented = true
+                            };
+                            _logger.LogWarning(System.Text.Json.JsonSerializer.Serialize(updatedMatchDetails, options));
                         }
                     }
                 }

--- a/src/FplBot.Tests/Helpers/TestBuilder.cs
+++ b/src/FplBot.Tests/Helpers/TestBuilder.cs
@@ -408,13 +408,17 @@ public static class TestBuilder
             {
                 new LineupContainer
                 {
-                    Formation = new Formation { Players = new IEnumerable<int>[0]},
-                    Lineup = new []{ new PlayerInLineup() }
+                    Formation = new Formation { Players = new List<int[]>{ new []{ 1 } } },
+                    Lineup = new []{ new PlayerInLineup { Id = 1, Name = new Name { First = "First", Last = "Lasteson", Display = "Lastinho"}, MatchPosition = "D"} }
                 },
                 new LineupContainer
                 {
-                    Formation = new Formation { Players = new IEnumerable<int>[0]},
-                    Lineup = new []{ new PlayerInLineup() }
+                    Formation = new Formation
+                    {
+                        Players = new List<int[]>{ new []{ 1 } }
+
+                    },
+                    Lineup = new []{ new PlayerInLineup { Id = 1, Name = new Name { First = "First", Last = "Lasteson", Display = "Lastinho"}, MatchPosition = "D"} }
                 }
             }
         };


### PR DESCRIPTION
After migrating to pulse-api for lineups, we get partial data (example, lineups without formation) instead of complete. Causes things to crash. Attempt at fix.