### PR TITLE
Append defensive contributions to the full time notification

### DIFF
--- a/src/Fpl.Client/FplConstants.cs
+++ b/src/Fpl.Client/FplConstants.cs
@@ -19,5 +19,17 @@ public class FplConstants
         public const string RedCards = "red_cards";
         public const string PenaltiesSaved = "penalties_saved";
         public const string PenaltiesMissed = "penalties_missed";
+        public const string Bps = "bps";
+        public const string DefensiveContribution = "defensive_contribution";
+    }
+
+    // https://www.premierleague.com/news/4324847
+    // Defenders earn defensive contribution points for 10+ clearances, blocks, interceptions and tackles.
+    // Midfielders and forwards earn them for 12+ clearances, blocks, interceptions, tackles and recoveries.
+    // Goalkeepers do not earn defensive contribution points.
+    public static class DefensiveContributionThresholds
+    {
+        public const int Defender = 10;
+        public const int MidfielderAndForward = 12;
     }
 }

--- a/src/FplBot.Formatting/DefensiveContributionPlayer.cs
+++ b/src/FplBot.Formatting/DefensiveContributionPlayer.cs
@@ -1,0 +1,9 @@
+using Fpl.Client.Models;
+
+namespace FplBot.Formatting;
+
+public class DefensiveContributionPlayer
+{
+    public Player Player { get; set; }
+    public int Contributions { get; set; }
+}

--- a/src/FplBot.Formatting/FinishedFixture.cs
+++ b/src/FplBot.Formatting/FinishedFixture.cs
@@ -10,4 +10,5 @@ public class FinishedFixture
     public Team AwayTeam { get; set; }
 
     public IEnumerable<BonusPointsPlayer> BonusPoints { get; set; } = new List<BonusPointsPlayer>();
+    public IEnumerable<DefensiveContributionPlayer> DefensiveContributions { get; set; } = new List<DefensiveContributionPlayer>();
 }

--- a/src/FplBot.Formatting/Formatter.cs
+++ b/src/FplBot.Formatting/Formatter.cs
@@ -340,7 +340,22 @@ public static class Formatter
             fullTimeReport += $"\nBonus points:\n";
             fullTimeReport += BulletPoints(bonusPointsOutput);
         }
+
+        if (fixture.DefensiveContributions.Any())
+        {
+            var defensiveContributionsOutput = CreateDefensiveContributionsOutput(fixture);
+            fullTimeReport += $"\nDefensive contributions:\n";
+            fullTimeReport += BulletPoints(defensiveContributionsOutput);
+        }
         return fullTimeReport;
+    }
+
+    public static IEnumerable<string> CreateDefensiveContributionsOutput(FinishedFixture fixture)
+    {
+        return fixture.DefensiveContributions
+            .OrderByDescending(dc => dc.Contributions)
+            .ThenBy(dc => dc.Player.WebName)
+            .Select(dc => $"{dc.Player.WebName} ({dc.Contributions})");
     }
 
     static string BonusPointRank(int bonusPoints, IEnumerable<Player> pall)

--- a/src/FplBot.Formatting/Helpers/FixtureFulltimeModelBuilder.cs
+++ b/src/FplBot.Formatting/Helpers/FixtureFulltimeModelBuilder.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Fpl.Client;
 using Fpl.Client.Models;
 
 namespace FplBot.Formatting.Helpers;
@@ -13,7 +14,8 @@ public static class FixtureFulltimeModelBuilder
             Fixture = n,
             HomeTeam = teams.First(t => t.Id == n.HomeTeamId),
             AwayTeam = teams.First(t => t.Id == n.AwayTeamId),
-            BonusPoints = CreateBonusPlayers(players, n)
+            BonusPoints = CreateBonusPlayers(players, n),
+            DefensiveContributions = CreateDefensiveContributionPlayers(players, n)
         };
     }
 
@@ -21,8 +23,8 @@ public static class FixtureFulltimeModelBuilder
     {
         try
         {
-            var bonusPointsHome = fixture.Stats.FirstOrDefault(s => s.Identifier == "bps")?.HomeStats;
-            var bonusPointsAway = fixture.Stats.FirstOrDefault(s => s.Identifier == "bps")?.AwayStats;
+            var bonusPointsHome = fixture.Stats.FirstOrDefault(s => s.Identifier == FplConstants.StatIdentifiers.Bps)?.HomeStats;
+            var bonusPointsAway = fixture.Stats.FirstOrDefault(s => s.Identifier == FplConstants.StatIdentifiers.Bps)?.AwayStats;
 
             var home = bonusPointsHome.Select(BpsFilter).ToList();
             var away = bonusPointsAway.Select(BpsFilter).ToList();
@@ -42,5 +44,55 @@ public static class FixtureFulltimeModelBuilder
         {
             return new List<BonusPointsPlayer>();
         }
+    }
+
+    // The FPL fixtures endpoint lists, under "defensive_contribution", every player who made at least one
+    // defensive contribution in the match together with their count. Only players reaching the threshold
+    // for their position are awarded points, so only those are kept here.
+    private static IEnumerable<DefensiveContributionPlayer> CreateDefensiveContributionPlayers(ICollection<Player> players, Fixture fixture)
+    {
+        try
+        {
+            var stat = fixture.Stats.FirstOrDefault(s => s.Identifier == FplConstants.StatIdentifiers.DefensiveContribution);
+            if (stat == null)
+                return new List<DefensiveContributionPlayer>();
+
+            var home = stat.HomeStats ?? new List<FixtureStatValue>();
+            var away = stat.AwayStats ?? new List<FixtureStatValue>();
+
+            return home.Concat(away)
+                .Select(ToDefensiveContributionPlayer)
+                .Where(dc => dc != null && ReachedThreshold(dc))
+                .OrderByDescending(dc => dc.Contributions)
+                .ThenBy(dc => dc.Player.WebName)
+                .ToList();
+
+            DefensiveContributionPlayer ToDefensiveContributionPlayer(FixtureStatValue value)
+            {
+                var player = players.FirstOrDefault(p => p.Id == value.Element);
+                if (player == null)
+                    return null;
+
+                return new DefensiveContributionPlayer
+                {
+                    Player = player,
+                    Contributions = value.Value
+                };
+            }
+        }
+        catch
+        {
+            return new List<DefensiveContributionPlayer>();
+        }
+    }
+
+    public static bool ReachedThreshold(DefensiveContributionPlayer dc)
+    {
+        return dc.Player.Position switch
+        {
+            FplPlayerPosition.Defender => dc.Contributions >= FplConstants.DefensiveContributionThresholds.Defender,
+            FplPlayerPosition.Midfielder or FplPlayerPosition.Forward => dc.Contributions >= FplConstants.DefensiveContributionThresholds.MidfielderAndForward,
+            _ => false
+        };
     }
 }

--- a/src/FplBot.Tests/Formatting/FixtureFulltimeModelBuilderTests.cs
+++ b/src/FplBot.Tests/Formatting/FixtureFulltimeModelBuilderTests.cs
@@ -1,0 +1,132 @@
+using Fpl.Client.Models;
+using FplBot.Formatting;
+using FplBot.Formatting.Helpers;
+
+namespace FplBot.Tests.Formatting;
+
+public class FixtureFulltimeModelBuilderTests
+{
+    private static readonly ICollection<Team> Teams = new[] { TestBuilder.HomeTeam(), TestBuilder.AwayTeam() };
+
+    [Fact]
+    public void WithDefensiveContributionStat_ResolvesQualifyingPlayersOrderedByContributions()
+    {
+        var players = Players(
+            TestBuilder.Player().WithPosition(FplPlayerPosition.Defender),
+            TestBuilder.OtherPlayer().WithPosition(FplPlayerPosition.Midfielder));
+        var fixture = TestBuilder.AwayTeamGoal(1, 1)
+            .FinishedProvisional()
+            .WithDefensiveContribution(TestBuilder.PlayerId, 10, TestBuilder.OtherPlayerId, 13);
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, players, fixture);
+
+        var contributions = finished.DefensiveContributions.ToList();
+        Assert.Equal(2, contributions.Count);
+        Assert.Equal(TestBuilder.OtherPlayerId, contributions[0].Player.Id);
+        Assert.Equal(13, contributions[0].Contributions);
+        Assert.Equal(TestBuilder.PlayerId, contributions[1].Player.Id);
+        Assert.Equal(10, contributions[1].Contributions);
+    }
+
+    [Fact]
+    public void PlayersBelowThreshold_AreExcluded()
+    {
+        var players = Players(
+            TestBuilder.Player().WithPosition(FplPlayerPosition.Defender),
+            TestBuilder.OtherPlayer().WithPosition(FplPlayerPosition.Midfielder));
+        var fixture = TestBuilder.AwayTeamGoal(1, 1)
+            .FinishedProvisional()
+            .WithDefensiveContribution(TestBuilder.PlayerId, 9, TestBuilder.OtherPlayerId, 11);
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, players, fixture);
+
+        Assert.Empty(finished.DefensiveContributions);
+    }
+
+    [Fact]
+    public void Goalkeeper_IsExcludedRegardlessOfCount()
+    {
+        var players = Players(
+            TestBuilder.Player().WithPosition(FplPlayerPosition.Goalkeeper),
+            TestBuilder.OtherPlayer().WithPosition(FplPlayerPosition.Forward));
+        var fixture = TestBuilder.AwayTeamGoal(1, 1)
+            .FinishedProvisional()
+            .WithDefensiveContribution(TestBuilder.PlayerId, 20, TestBuilder.OtherPlayerId, 12);
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, players, fixture);
+
+        var only = Assert.Single(finished.DefensiveContributions);
+        Assert.Equal(TestBuilder.OtherPlayerId, only.Player.Id);
+    }
+
+    [Theory]
+    [InlineData(FplPlayerPosition.Goalkeeper, 30, false)]
+    [InlineData(FplPlayerPosition.Defender, 9, false)]
+    [InlineData(FplPlayerPosition.Defender, 10, true)]
+    [InlineData(FplPlayerPosition.Midfielder, 11, false)]
+    [InlineData(FplPlayerPosition.Midfielder, 12, true)]
+    [InlineData(FplPlayerPosition.Forward, 11, false)]
+    [InlineData(FplPlayerPosition.Forward, 12, true)]
+    [InlineData(FplPlayerPosition.NotSet, 30, false)]
+    public void ReachedThreshold_FollowsPositionRules(FplPlayerPosition position, int contributions, bool expected)
+    {
+        var dc = new DefensiveContributionPlayer
+        {
+            Player = new Player { Position = position },
+            Contributions = contributions
+        };
+
+        Assert.Equal(expected, FixtureFulltimeModelBuilder.ReachedThreshold(dc));
+    }
+
+    [Fact]
+    public void WithoutDefensiveContributionStat_ReturnsEmpty()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, DefaultPlayers(), fixture);
+
+        Assert.Empty(finished.DefensiveContributions);
+    }
+
+    [Fact]
+    public void WithEmptyDefensiveContributionStat_ReturnsEmpty()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional().WithEmptyDefensiveContribution();
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, DefaultPlayers(), fixture);
+
+        Assert.Empty(finished.DefensiveContributions);
+    }
+
+    [Fact]
+    public void WithUnknownPlayerInDefensiveContributionStat_SkipsThatPlayer()
+    {
+        var players = Players(TestBuilder.Player().WithPosition(FplPlayerPosition.Defender));
+        var fixture = TestBuilder.AwayTeamGoal(1, 1)
+            .FinishedProvisional()
+            .WithDefensiveContribution(TestBuilder.PlayerId, 11, 999999, 12);
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, players, fixture);
+
+        var only = Assert.Single(finished.DefensiveContributions);
+        Assert.Equal(TestBuilder.PlayerId, only.Player.Id);
+    }
+
+    [Fact]
+    public void BonusPointsStillBuiltFromBps()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).WithProvisionalBonus(TestBuilder.PlayerId, 30);
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, DefaultPlayers(), fixture);
+
+        var only = Assert.Single(finished.BonusPoints);
+        Assert.Equal(30, only.BonusPoints);
+    }
+
+    private static ICollection<Player> DefaultPlayers() => Players(
+        TestBuilder.Player().WithPosition(FplPlayerPosition.Defender),
+        TestBuilder.OtherPlayer().WithPosition(FplPlayerPosition.Midfielder));
+
+    private static ICollection<Player> Players(params Player[] players) => players;
+}

--- a/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
+++ b/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
@@ -103,6 +103,51 @@ public class FulltimeFormattingTests
         })));
     }
 
+    [Fact]
+    public void DefensiveContributionsOnly_ListsPlayersByContributionsDescending()
+    {
+        var fixture = GetProvisionalFinishedFixture();
+        fixture.DefensiveContributions = new[]
+        {
+            DefensiveContributionPlayer("player-B", 12),
+            DefensiveContributionPlayer("player-A", 10),
+            DefensiveContributionPlayer("player-C", 14)
+        };
+
+        var output = Formatter.FormatProvisionalFinished(fixture);
+        _helper.WriteLine(output);
+
+        Assert.DoesNotContain("Bonus points:", output);
+        Assert.Contains("Defensive contributions:", output);
+        Assert.Equal(new[] { "player-C (14)", "player-B (12)", "player-A (10)" }, Formatter.CreateDefensiveContributionsOutput(fixture));
+    }
+
+    [Fact]
+    public void BonusAndDefensiveContributions_BonusComesFirst()
+    {
+        var fixture = GetProvisionalFinishedFixture(
+            BonusPointsPlayer("player-C", 30),
+            BonusPointsPlayer("player-B", 40),
+            BonusPointsPlayer("player-A", 50));
+        fixture.DefensiveContributions = new[] { DefensiveContributionPlayer("player-D", 11) };
+
+        var output = Formatter.FormatProvisionalFinished(fixture);
+        _helper.WriteLine(output);
+
+        var bonusIndex = output.IndexOf("Bonus points:", StringComparison.Ordinal);
+        var dcIndex = output.IndexOf("Defensive contributions:", StringComparison.Ordinal);
+        Assert.True(bonusIndex >= 0);
+        Assert.True(dcIndex > bonusIndex);
+        Assert.Contains("▪️ player-D (11)", output);
+    }
+
+    [Fact]
+    public void NoBonusAndNoDefensiveContributions_ReturnsEmpty()
+    {
+        var output = Formatter.FormatProvisionalFinished(GetProvisionalFinishedFixture());
+        Assert.Equal(string.Empty, output);
+    }
+
     private FinishedFixture GetProvisionalFinishedFixture(params BonusPointsPlayer[] bonusPointsPlayers)
     {
         return new FinishedFixture
@@ -113,6 +158,15 @@ public class FulltimeFormattingTests
                 BonusPoints = bonusPointsPlayers
             }
             ;
+    }
+
+    DefensiveContributionPlayer DefensiveContributionPlayer(string webName, int contributions)
+    {
+        return new DefensiveContributionPlayer
+        {
+            Player = new Player { WebName = webName },
+            Contributions = contributions
+        };
     }
     BonusPointsPlayer BonusPointsPlayer(string webName, int bonusPoints)
     {

--- a/src/FplBot.Tests/Helpers/TestBuilder.cs
+++ b/src/FplBot.Tests/Helpers/TestBuilder.cs
@@ -1,3 +1,4 @@
+using Fpl.Client;
 using Fpl.Client.Models;
 using Fpl.EventPublishers;
 using FplBot.Data.Slack;
@@ -204,6 +205,28 @@ public static class TestBuilder
         return fixture;
     }
 
+    public static Fixture WithDefensiveContribution(this Fixture fixture, int homePlayerId, int homeContributions, int awayPlayerId, int awayContributions)
+    {
+        fixture.Stats = fixture.Stats.Append(new FixtureStat
+        {
+            Identifier = FplConstants.StatIdentifiers.DefensiveContribution,
+            HomeStats = new List<FixtureStatValue> { new() { Element = homePlayerId, Value = homeContributions } },
+            AwayStats = new List<FixtureStatValue> { new() { Element = awayPlayerId, Value = awayContributions } }
+        }).ToArray();
+        return fixture;
+    }
+
+    public static Fixture WithEmptyDefensiveContribution(this Fixture fixture)
+    {
+        fixture.Stats = fixture.Stats.Append(new FixtureStat
+        {
+            Identifier = FplConstants.StatIdentifiers.DefensiveContribution,
+            HomeStats = new List<FixtureStatValue>(),
+            AwayStats = new List<FixtureStatValue>()
+        }).ToArray();
+        return fixture;
+    }
+
     private static FixtureStat BpsSystem(int playerId, int bps)
     {
         return new FixtureStat
@@ -331,6 +354,12 @@ public static class TestBuilder
     public static Player FromAwayTeam(this Player player)
     {
         player.TeamCode = AwayTeamId;
+        return player;
+    }
+
+    public static Player WithPosition(this Player player, FplPlayerPosition position)
+    {
+        player.Position = position;
         return player;
     }
 


### PR DESCRIPTION
Append defensive contributions to the full time notification

Adds a "Defensive contributions" section after the bonus points in the
provisional full time thread message, for both Slack and Discord.

The FPL fixtures endpoint now includes a `defensive_contribution` stat
listing every player who made at least one contribution with their
count. Only players who reach the threshold for their position are
listed: 10 for defenders, 12 for midfielders and forwards, goalkeepers
excluded. Players are sorted by count descending, then by name.

Example thread:

    Bonus points:
    ▪️ 3p Saliba
    ▪️ 2p Gabriel
    ▪️ 1p Raya

    Defensive contributions:
    ▪️ Gabriel (14)
    ▪️ Rice (12)
    ▪️ Saliba (10)

Also replaces the hard coded "bps" stat identifier with a constant.

Tests: new cases in FulltimeFormattingTests, a new
FixtureFulltimeModelBuilderTests class covering threshold boundaries per
position, unknown players, and empty or missing stats.
