### PR TITLE
Separate bonus points and defensive contributions with a blank line

### DIFF
--- a/src/FplBot.Formatting/Formatter.cs
+++ b/src/FplBot.Formatting/Formatter.cs
@@ -344,6 +344,10 @@ public static class Formatter
         if (fixture.DefensiveContributions.Any())
         {
             var defensiveContributionsOutput = CreateDefensiveContributionsOutput(fixture);
+            if (fullTimeReport.Length > 0)
+            {
+                fullTimeReport += "\n"; // blank line between the bonus points and the defensive contributions
+            }
             fullTimeReport += $"\nDefensive contributions:\n";
             fullTimeReport += BulletPoints(defensiveContributionsOutput);
         }

--- a/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
+++ b/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
@@ -139,6 +139,18 @@ public class FulltimeFormattingTests
         Assert.True(bonusIndex >= 0);
         Assert.True(dcIndex > bonusIndex);
         Assert.Contains("▪️ player-D (11)", output);
+        Assert.Contains("▪️ 1p player-C\n\nDefensive contributions:", output);
+    }
+
+    [Fact]
+    public void DefensiveContributionsOnly_DoesNotStartWithBlankLine()
+    {
+        var fixture = GetProvisionalFinishedFixture();
+        fixture.DefensiveContributions = new[] { DefensiveContributionPlayer("player-A", 12) };
+
+        var output = Formatter.FormatProvisionalFinished(fixture);
+
+        Assert.StartsWith("\nDefensive contributions:\n", output);
     }
 
     [Fact]


### PR DESCRIPTION
Separate bonus points and defensive contributions with a blank line

Follow-up to the defensive contributions PR. In Slack the two sections
ran together with no gap. This adds a blank line before the
"Defensive contributions" header when bonus points are shown above it.
A fixture with only defensive contributions is unchanged.