### PR TITLE
fix: add blank line between bonus points and defensive contributions

### DIFF
--- a/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
+++ b/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
@@ -139,6 +139,18 @@ public class FulltimeFormattingTests
         Assert.True(bonusIndex >= 0);
         Assert.True(dcIndex > bonusIndex);
         Assert.Contains("▪️ player-D (11)", output);
+        Assert.Contains("▪️ 1p player-C\n\nDefensive contributions:", output);
+    }
+
+    [Fact]
+    public void DefensiveContributionsOnly_DoesNotStartWithBlankLine()
+    {
+        var fixture = GetProvisionalFinishedFixture();
+        fixture.DefensiveContributions = new[] { DefensiveContributionPlayer("player-A", 12) };
+
+        var output = Formatter.FormatProvisionalFinished(fixture);
+
+        Assert.StartsWith("\nDefensive contributions:\n", output);
     }
 
     [Fact]

--- a/src/FplBot/Formatting/Formatter.cs
+++ b/src/FplBot/Formatting/Formatter.cs
@@ -340,6 +340,10 @@ public static class Formatter
         if (fixture.DefensiveContributions.Any())
         {
             var defensiveContributionsOutput = CreateDefensiveContributionsOutput(fixture);
+            if (fullTimeReport.Length > 0)
+            {
+                fullTimeReport += "\n"; // blank line between the bonus points and the defensive contributions
+            }
             fullTimeReport += $"\nDefensive contributions:\n";
             fullTimeReport += BulletPoints(defensiveContributionsOutput);
         }


### PR DESCRIPTION
Brings in the changes from #363 by @janode (which couldn't be rebased due to main diverging too much).

## Summary
- Adds a blank line before "Defensive contributions:" when bonus points are shown above it
- A fixture with only defensive contributions is unchanged

Credits: original implementation by @janode in #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)