### PR TITLE
fix: add env to bobheadxi/deployments finish steps

### DIFF
--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -62,3 +62,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env: production

--- a/.github/workflows/DeployToTest.yml
+++ b/.github/workflows/DeployToTest.yml
@@ -61,3 +61,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env: test


### PR DESCRIPTION
`bobheadxi/deployments@v1` now requires `env` on the `finish` step, not just `start`. Adds `env: test` and `env: production` to the finish steps in both deploy workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)