### PR TITLE
Dep updates, CI cleanup, Renovate setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,6 @@ jobs:
   ci-on-ubuntu:
     name: ci
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6
@@ -20,7 +17,3 @@ jobs:
           dotnet-version: "10.0.x"
       - name: Test
         run: dotnet run --project src/Build -- test
-        env:
-          fpl__login: ${{ secrets.fpl__login }}
-          fpl__password: ${{ secrets.fpl__password }}
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -62,3 +62,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env: production

--- a/.github/workflows/DeployToTest.yml
+++ b/.github/workflows/DeployToTest.yml
@@ -61,3 +61,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env: test

--- a/.github/workflows/Renovate.yml
+++ b/.github/workflows/Renovate.yml
@@ -1,0 +1,35 @@
+name: Renovate
+
+on:
+  schedule:
+    # Run daily at 05:00 UTC (07:00 Oslo time)
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      log_level:
+        description: "Renovate log level"
+        required: false
+        default: "info"
+        type: choice
+        options:
+          - debug
+          - info
+          - warn
+
+jobs:
+  renovate:
+    name: Renovate dependency updates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v41
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "Europe/Oslo",
+  "schedule": ["before 6am on Monday"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group xunit packages",
+      "matchPackageNames": [
+        "xunit",
+        "xunit.runner.visualstudio",
+        "xunit.abstractions"
+      ],
+      "groupName": "xunit",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group Microsoft.Extensions.* packages",
+      "matchPackagePatterns": ["^Microsoft\\.Extensions\\."],
+      "groupName": "Microsoft.Extensions",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group Microsoft.AspNetCore.* packages",
+      "matchPackagePatterns": ["^Microsoft\\.AspNetCore\\."],
+      "groupName": "Microsoft.AspNetCore",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group Microsoft.NET.* packages",
+      "matchPackagePatterns": ["^Microsoft\\.NET\\."],
+      "groupName": "Microsoft.NET",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group Serilog packages",
+      "matchPackagePatterns": ["^Serilog"],
+      "groupName": "Serilog",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group MassTransit packages — pin to major 8, skip major bumps",
+      "matchPackagePatterns": ["^MassTransit"],
+      "groupName": "MassTransit",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": false,
+      "ignorePaths": [],
+      "allowedVersions": "<9"
+    },
+    {
+      "description": "Group Slackbot.Net packages",
+      "matchPackagePatterns": ["^Slackbot\\.Net"],
+      "groupName": "Slackbot.Net",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": false
+    },
+    {
+      "description": "Group Testcontainers packages",
+      "matchPackagePatterns": ["^Testcontainers"],
+      "groupName": "Testcontainers",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group GitHub Actions — actions org",
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": ["^actions/"],
+      "groupName": "GitHub Actions (actions/*)",
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group GitHub Actions — other orgs",
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": ["^(?!actions/)"],
+      "groupName": "GitHub Actions (third-party)",
+      "automerge": false,
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Never automerge major bumps for any package",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "Automerge patch updates for safe utility packages",
+      "matchPackageNames": [
+        "FakeItEasy",
+        "coverlet.collector",
+        "GitHubActionsTestLogger",
+        "Bullseye",
+        "SimpleExec",
+        "Fastenshtein",
+        "MinimalHttpLogger"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    }
+  ],
+  "nuget": {
+    "enabled": true
+  },
+  "ignorePaths": []
+}

--- a/src/FplBot.AppHost/FplBot.AppHost.csproj
+++ b/src/FplBot.AppHost/FplBot.AppHost.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.3" />
     <PackageReference Include="Aspire.Hosting.Redis" Version="13.5.3" />
     <PackageReference Include="AlmostServiceBus.Aspire.Hosting" Version="0.3.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.31" />
   </ItemGroup>
 </Project>

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -20,7 +20,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FakeItEasy" Version="7.2.0" />
+        <PackageReference Include="FakeItEasy" Version="9.0.1" />
         <PackageReference Include="Testcontainers.Redis" Version="4.15.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
         <PackageReference Include="StackExchange.Redis" Version="3.1.31" />

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -10,13 +10,13 @@
 
     <ItemGroup>
         <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -21,7 +21,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FakeItEasy" Version="7.2.0" />
-        <PackageReference Include="Testcontainers.Redis" Version="4.14.0" />
+        <PackageReference Include="Testcontainers.Redis" Version="4.15.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
         <PackageReference Include="StackExchange.Redis" Version="3.1.31" />
     </ItemGroup>

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="FakeItEasy" Version="7.2.0" />
         <PackageReference Include="Testcontainers.Redis" Version="4.14.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
-        <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
+        <PackageReference Include="StackExchange.Redis" Version="3.1.31" />
     </ItemGroup>
 
     <ItemGroup Condition="Exists('appsettings.Local.json')">

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+        <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
@@ -22,7 +22,7 @@
         </PackageReference>
         <PackageReference Include="FakeItEasy" Version="7.2.0" />
         <PackageReference Include="Testcontainers.Redis" Version="4.14.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
         <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
     </ItemGroup>
 

--- a/src/FplBot.Tests/Helpers/CustomAssert.cs
+++ b/src/FplBot.Tests/Helpers/CustomAssert.cs
@@ -14,6 +14,6 @@ public static class CustomAssert
             return;
         }
 
-        throw new ContainsException(string.Join("\n", possibleSubstrings), actualString);
+        throw new XunitException($"Expected actual string to contain any of:\n{string.Join("\n", possibleSubstrings)}\nActual: {actualString}");
     }
 }

--- a/src/FplBot.slnx
+++ b/src/FplBot.slnx
@@ -1,6 +1,10 @@
 <Solution>
-  <Project Path="Build/Build.csproj" />
-  <Project Path="FplBot.AppHost/FplBot.AppHost.csproj" />
+  <Project Path="Build/Build.csproj">
+    <ConfigurationRule BuildType="None" />
+  </Project>
+  <Project Path="FplBot.AppHost/FplBot.AppHost.csproj">
+    <ConfigurationRule BuildType="None" />
+  </Project>
   <Project Path="FplBot.Tests/FplBot.Tests.csproj" />
   <Project Path="FplBot/FplBot.csproj" />
 </Solution>

--- a/src/FplBot/FplBot.csproj
+++ b/src/FplBot/FplBot.csproj
@@ -39,12 +39,12 @@
     <PackageReference Include="Slackbot.Net.SlackClients.Http" Version="8.1.4" />
 
     <!-- Logging -->
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 
     <!-- Misc -->
     <PackageReference Include="MinimalHttpLogger" Version="0.1.2" />

--- a/src/FplBot/FplBot.csproj
+++ b/src/FplBot/FplBot.csproj
@@ -24,14 +24,14 @@
     <PackageReference Include="NEST" Version="7.17.5" />
 
     <!-- Event scheduling -->
-    <PackageReference Include="CronBackgroundServices" Version="8.0.0" />
+    <PackageReference Include="CronBackgroundServices" Version="9.0.0" />
 
     <!-- Formatting -->
     <PackageReference Include="Fastenshtein" Version="1.0.12" />
 
     <!-- Web / Auth -->
     <PackageReference Include="AspNet.Security.OAuth.Slack" Version="10.0.0" />
-    <PackageReference Include="NSec.Cryptography" Version="20.2.0" />
+    <PackageReference Include="NSec.Cryptography" Version="26.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.11" />
 
     <!-- Slack -->
@@ -47,7 +47,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 
     <!-- Misc -->
-    <PackageReference Include="MinimalHttpLogger" Version="0.1.2" />
+    <PackageReference Include="MinimalHttpLogger" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/FplBot/FplBot.csproj
+++ b/src/FplBot/FplBot.csproj
@@ -17,8 +17,8 @@
 
     <!-- Data / Redis -->
     <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.11" />
 
     <!-- Search -->
     <PackageReference Include="NEST" Version="7.14.1" />
@@ -32,7 +32,7 @@
     <!-- Web / Auth -->
     <PackageReference Include="AspNet.Security.OAuth.Slack" Version="10.0.0" />
     <PackageReference Include="NSec.Cryptography" Version="20.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.11" />
 
     <!-- Slack -->
     <PackageReference Include="Slackbot.Net.Endpoints" Version="8.1.4" />

--- a/src/FplBot/FplBot.csproj
+++ b/src/FplBot/FplBot.csproj
@@ -21,13 +21,13 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.11" />
 
     <!-- Search -->
-    <PackageReference Include="NEST" Version="7.14.1" />
+    <PackageReference Include="NEST" Version="7.17.5" />
 
     <!-- Event scheduling -->
     <PackageReference Include="CronBackgroundServices" Version="8.0.0" />
 
     <!-- Formatting -->
-    <PackageReference Include="Fastenshtein" Version="1.0.0.7" />
+    <PackageReference Include="Fastenshtein" Version="1.0.12" />
 
     <!-- Web / Auth -->
     <PackageReference Include="AspNet.Security.OAuth.Slack" Version="10.0.0" />

--- a/src/FplBot/FplBot.csproj
+++ b/src/FplBot/FplBot.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="8.5.10" />
 
     <!-- Data / Redis -->
-    <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.31" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.11" />
 


### PR DESCRIPTION
## Summary
- Bump all NuGet dependencies to latest (Serilog, Microsoft.Extensions, StackExchange.Redis 3.x, xunit 2.9, FakeItEasy 9, NSec, CronBackgroundServices, etc.) — MassTransit pinned at 8.x intentionally
- Fix xunit 2.9 compat: `ContainsException` constructor changed, switched to `XunitException`
- Update `GitHubActionsTestLogger` 1.2.0 → 3.0.5
- CI cleanup: remove unused `fpl__login`/`fpl__password` secrets and `NUGET_AUTH_TOKEN`; remove redundant permissions block
- Mark `Build.csproj` and `FplBot.AppHost.csproj` as `BuildType=None` in `.slnx` so they're excluded from solution builds
- Add Renovate via GitHub Actions (daily at 07:00 Oslo, automerges safe patch/minor, MassTransit capped at <9)

## Test plan
- [x] 217 tests pass locally after each batch
- [x] All services run locally — 0 build warnings, 0 runtime errors, all consumers registered, bus started
- [x] CI passes on GitHub (54s)
- [x] Test deploy succeeded and ran from branch tip `57cca96`
- [x] Heroku app logs clean — all recurring actions firing, FPL API healthy, Redis healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)