### PR TITLE
refactor: prefix Discord/Slack handler class names to get separate ASB queues

### DIFF
--- a/src/FplBot/Services/EventHandlers/Discord/DiscordFixtureEventsHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordFixtureEventsHandler.cs
@@ -11,9 +11,9 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class FixtureEventsHandler(
+public class DiscordFixtureEventsHandler(
     IGuildRepository repo,
-    ILogger<FixtureEventsHandler> logger,
+    ILogger<DiscordFixtureEventsHandler> logger,
     IGlobalSettingsClient globalSettingsClient,
     ILeagueEntriesByGameweek leagueEntriesByGameweek,
     ITransfersByGameWeek transfersByGameWeek)

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordFixtureFulltimeHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordFixtureFulltimeHandler.cs
@@ -9,14 +9,14 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class FixtureFulltimeHandler(
+public class DiscordFixtureFulltimeHandler(
     IGuildRepository teamRepo,
-    ILogger<NearDeadlineHandler> logger,
+    ILogger<DiscordFixtureFulltimeHandler> logger,
     IGlobalSettingsClient settingsClient,
     IFixtureClient fixtureClient)
     : IConsumer<FixtureFinished>
 {
-    private readonly ILogger<NearDeadlineHandler> _logger = logger;
+    private readonly ILogger<DiscordFixtureFulltimeHandler> _logger = logger;
 
     public async Task Consume(ConsumeContext<FixtureFinished> context)
     {

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordFixtureRemovedHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordFixtureRemovedHandler.cs
@@ -6,9 +6,9 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class FixtureRemovedFromGameweekHandler(
+public class DiscordFixtureRemovedHandler(
     IGuildRepository guildRepo,
-    ILogger<FixtureRemovedFromGameweekHandler> logger)
+    ILogger<DiscordFixtureRemovedHandler> logger)
     : IConsumer<FixtureRemovedFromGameweek>
 {
     public async Task Consume(ConsumeContext<FixtureRemovedFromGameweek> context)

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordGameweekFinishedHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordGameweekFinishedHandler.cs
@@ -8,9 +8,9 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class GameweekFinishedHandler(
+public class DiscordGameweekFinishedHandler(
     IGuildRepository repo,
-    ILogger<GameweekFinishedHandler> logger,
+    ILogger<DiscordGameweekFinishedHandler> logger,
     IGlobalSettingsClient settingsClient,
     ILeagueClient leagueClient)
     : IConsumer<GameweekFinished>,

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordGameweekStartedHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordGameweekStartedHandler.cs
@@ -10,12 +10,12 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class GameweekStartedHandler(
+public class DiscordGameweekStartedHandler(
     IGuildRepository repo,
     ILeagueClient leagueClient,
     ICaptainsByGameWeek captainsByGameweek,
     ITransfersByGameWeek transfersByGameweek,
-    ILogger<GameweekStartedHandler> logger)
+    ILogger<DiscordGameweekStartedHandler> logger)
     : IConsumer<GameweekJustBegan>, IConsumer<ProcessGameweekStartedForGuildChannel>
 {
     private const int MemberCountForLargeLeague = 25;

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordInjuryUpdateHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordInjuryUpdateHandler.cs
@@ -7,7 +7,7 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class InjuryUpdateHandler(IGuildRepository repo, ILogger<InjuryUpdateHandler> logger)
+public class DiscordInjuryUpdateHandler(IGuildRepository repo, ILogger<DiscordInjuryUpdateHandler> logger)
     : IConsumer<InjuryUpdateOccured>
 {
     public async Task Consume(ConsumeContext<InjuryUpdateOccured> context)

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordLineupReadyHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordLineupReadyHandler.cs
@@ -7,7 +7,7 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class LineupReadyHandler(IGuildRepository guildRepository) : IConsumer<LineupReady>
+public class DiscordLineupReadyHandler(IGuildRepository guildRepository) : IConsumer<LineupReady>
 {
     public async Task Consume(ConsumeContext<LineupReady> context)
     {

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordNearDeadlineHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordNearDeadlineHandler.cs
@@ -6,7 +6,7 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class NearDeadlineHandler(IGuildRepository teamRepo, ILogger<NearDeadlineHandler> logger)
+public class DiscordNearDeadlineHandler(IGuildRepository teamRepo, ILogger<DiscordNearDeadlineHandler> logger)
     :
         IConsumer<OneHourToDeadline>,
         IConsumer<TwentyFourHoursToDeadline>

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordNewPlayersHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordNewPlayersHandler.cs
@@ -7,7 +7,7 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class NewPlayersHandler(IGuildRepository repo, ILogger<InjuryUpdateHandler> logger)
+public class DiscordNewPlayersHandler(IGuildRepository repo, ILogger<DiscordNewPlayersHandler> logger)
     : IConsumer<NewPlayersRegistered>, IConsumer<PremiershipPlayerTransferred>
 {
     public async Task Consume(ConsumeContext<NewPlayersRegistered> context)

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordPriceChangeHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordPriceChangeHandler.cs
@@ -7,7 +7,7 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Discord;
 
-public class PriceChangeHandler(IGuildRepository repo, ILogger<PriceChangeHandler> logger)
+public class DiscordPriceChangeHandler(IGuildRepository repo, ILogger<DiscordPriceChangeHandler> logger)
     : IConsumer<PlayersPriceChanged>
 {
     public async Task Consume(ConsumeContext<PlayersPriceChanged> context)

--- a/src/FplBot/Services/EventHandlers/EventHandlersService.cs
+++ b/src/FplBot/Services/EventHandlers/EventHandlersService.cs
@@ -7,27 +7,6 @@ using FplBot.Hosting;
 using MassTransit;
 using StackExchange.Redis;
 
-using DiscordFixtureEventsHandler = FplBot.EventHandlers.Discord.FixtureEventsHandler;
-using DiscordFixtureFulltimeHandler = FplBot.EventHandlers.Discord.FixtureFulltimeHandler;
-using DiscordGameweekFinishedHandler = FplBot.EventHandlers.Discord.GameweekFinishedHandler;
-using DiscordGameweekStartedHandler = FplBot.EventHandlers.Discord.GameweekStartedHandler;
-using DiscordInjuryUpdateHandler = FplBot.EventHandlers.Discord.InjuryUpdateHandler;
-using DiscordLineupReadyHandler = FplBot.EventHandlers.Discord.LineupReadyHandler;
-using DiscordNearDeadlineHandler = FplBot.EventHandlers.Discord.NearDeadlineHandler;
-using DiscordNewPlayersHandler = FplBot.EventHandlers.Discord.NewPlayersHandler;
-using DiscordPriceChangeHandler = FplBot.EventHandlers.Discord.PriceChangeHandler;
-using DiscordFixtureRemovedHandler = FplBot.EventHandlers.Discord.FixtureRemovedFromGameweekHandler;
-using SlackFixtureEventsHandler = FplBot.EventHandlers.Slack.FixtureEventsHandler;
-using SlackFixtureFulltimeHandler = FplBot.EventHandlers.Slack.FixtureFulltimeHandler;
-using SlackGameweekFinishedHandler = FplBot.EventHandlers.Slack.GameweekFinishedHandler;
-using SlackGameweekStartedHandler = FplBot.EventHandlers.Slack.GameweekStartedHandler;
-using SlackInjuryUpdateHandler = FplBot.EventHandlers.Slack.InjuryUpdateHandler;
-using SlackLineupReadyHandler = FplBot.EventHandlers.Slack.LineupReadyHandler;
-using SlackNearDeadlineHandler = FplBot.EventHandlers.Slack.NearDeadlineHandler;
-using SlackNewPlayerHandler = FplBot.EventHandlers.Slack.NewPlayerHandler;
-using SlackPriceChangeHandler = FplBot.EventHandlers.Slack.PriceChangeHandler;
-using SlackFixtureRemovedHandler = FplBot.EventHandlers.Slack.FixtureRemovedFromGameweekHandler;
-
 namespace FplBot.Services.EventHandlers;
 
 public class EventHandlersService : IFplBotService

--- a/src/FplBot/Services/EventHandlers/Slack/SlackFixtureEventsHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackFixtureEventsHandler.cs
@@ -13,14 +13,14 @@ using Slackbot.Net.SlackClients.Http.Models.Responses.UsersList;
 
 namespace FplBot.EventHandlers.Slack;
 
-public class FixtureEventsHandler(
+public class SlackFixtureEventsHandler(
     ISlackWorkSpacePublisher publisher,
     ISlackTeamRepository slackTeamRepo,
     ISlackClientBuilder service,
     ILeagueEntriesByGameweek leagueEntriesByGameweek,
     ITransfersByGameWeek transfersByGameWeek,
     IGlobalSettingsClient globalSettingsClient,
-    ILogger<FixtureEventsHandler> logger)
+    ILogger<SlackFixtureEventsHandler> logger)
     : IConsumer<FixtureEventsOccured>, IConsumer<PublishFixtureEventsToSlackWorkspace>
 {
     public async Task Consume(ConsumeContext<FixtureEventsOccured> context)

--- a/src/FplBot/Services/EventHandlers/Slack/SlackFixtureFulltimeHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackFixtureFulltimeHandler.cs
@@ -11,10 +11,10 @@ using Slackbot.Net.SlackClients.Http.Models.Requests.ChatPostMessage;
 
 namespace FplBot.EventHandlers.Slack;
 
-public class FixtureFulltimeHandler(
+public class SlackFixtureFulltimeHandler(
     ISlackClientBuilder builder,
     ISlackTeamRepository slackTeamRepo,
-    ILogger<FixtureFulltimeHandler> logger,
+    ILogger<SlackFixtureFulltimeHandler> logger,
     IGlobalSettingsClient settingsClient,
     IFixtureClient fixtureClient)
     : IConsumer<FixtureFinished>, IConsumer<PublishFulltimeMessageToSlackWorkspace>

--- a/src/FplBot/Services/EventHandlers/Slack/SlackFixtureRemovedHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackFixtureRemovedHandler.cs
@@ -6,9 +6,9 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Slack;
 
-public class FixtureRemovedFromGameweekHandler(
+public class SlackFixtureRemovedHandler(
     ISlackTeamRepository teamRepo,
-    ILogger<FixtureRemovedFromGameweekHandler> logger)
+    ILogger<SlackFixtureRemovedHandler> logger)
     : IConsumer<FixtureRemovedFromGameweek>
 {
     public async Task Consume(ConsumeContext<FixtureRemovedFromGameweek> context)

--- a/src/FplBot/Services/EventHandlers/Slack/SlackGameweekFinishedHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackGameweekFinishedHandler.cs
@@ -10,7 +10,7 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Slack;
 
-internal class GameweekFinishedHandler(
+internal class SlackGameweekFinishedHandler(
     ISlackWorkSpacePublisher publisher,
     ISlackTeamRepository teamsRepo,
     ILeagueClient leagueClient,

--- a/src/FplBot/Services/EventHandlers/Slack/SlackGameweekStartedHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackGameweekStartedHandler.cs
@@ -11,13 +11,13 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Slack;
 
-internal class GameweekStartedHandler(
+internal class SlackGameweekStartedHandler(
     ICaptainsByGameWeek captainsByGameweek,
     ITransfersByGameWeek transfersByGameweek,
     ISlackWorkSpacePublisher publisher,
     ISlackTeamRepository teamsRepo,
     ILeagueClient leagueClient,
-    ILogger<GameweekStartedHandler> logger)
+    ILogger<SlackGameweekStartedHandler> logger)
     : IConsumer<GameweekJustBegan>, IConsumer<ProcessGameweekStartedForSlackWorkspace>
 {
     private const int MemberCountForLargeLeague = 25;

--- a/src/FplBot/Services/EventHandlers/Slack/SlackInjuryUpdateHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackInjuryUpdateHandler.cs
@@ -7,7 +7,7 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Slack;
 
-public class InjuryUpdateHandler(ISlackTeamRepository slackTeamRepo, ILogger<InjuryUpdateHandler> logger)
+public class SlackInjuryUpdateHandler(ISlackTeamRepository slackTeamRepo, ILogger<SlackInjuryUpdateHandler> logger)
     : IConsumer<InjuryUpdateOccured>
 {
     public async Task Consume(ConsumeContext<InjuryUpdateOccured> context)

--- a/src/FplBot/Services/EventHandlers/Slack/SlackLineupReadyHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackLineupReadyHandler.cs
@@ -8,10 +8,10 @@ using Slackbot.Net.SlackClients.Http;
 
 namespace FplBot.EventHandlers.Slack;
 
-public class LineupReadyHandler(
+public class SlackLineupReadyHandler(
     ISlackTeamRepository slackTeamRepo,
     ISlackClientBuilder builder,
-    ILogger<LineupReadyHandler> logger)
+    ILogger<SlackLineupReadyHandler> logger)
     : IConsumer<LineupReady>, IConsumer<PublishLineupsToSlackWorkspace>
 {
     public async Task Consume(ConsumeContext<LineupReady> context)

--- a/src/FplBot/Services/EventHandlers/Slack/SlackNearDeadlineHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackNearDeadlineHandler.cs
@@ -10,12 +10,12 @@ using Slackbot.Net.SlackClients.Http.Models.Requests.ChatPostMessage;
 
 namespace FplBot.EventHandlers.Slack;
 
-public class NearDeadlineHandler(
+public class SlackNearDeadlineHandler(
     ISlackTeamRepository teamRepo,
     ISlackClientBuilder builder,
     IGlobalSettingsClient globalSettingsClient,
     IFixtureClient fixtures,
-    ILogger<NearDeadlineHandler> logger)
+    ILogger<SlackNearDeadlineHandler> logger)
     :
         IConsumer<OneHourToDeadline>,
         IConsumer<TwentyFourHoursToDeadline>,

--- a/src/FplBot/Services/EventHandlers/Slack/SlackNewPlayerHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackNewPlayerHandler.cs
@@ -7,7 +7,7 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Slack;
 
-public class NewPlayerHandler(ISlackTeamRepository slackTeamRepo, ILogger<NewPlayerHandler> logger)
+public class SlackNewPlayerHandler(ISlackTeamRepository slackTeamRepo, ILogger<SlackNewPlayerHandler> logger)
     : IConsumer<NewPlayersRegistered>, IConsumer<PremiershipPlayerTransferred>
 {
     public async Task Consume(ConsumeContext<NewPlayersRegistered> context)

--- a/src/FplBot/Services/EventHandlers/Slack/SlackPriceChangeHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackPriceChangeHandler.cs
@@ -7,10 +7,10 @@ using MassTransit;
 
 namespace FplBot.EventHandlers.Slack;
 
-public class PriceChangeHandler(
+public class SlackPriceChangeHandler(
     ISlackWorkSpacePublisher publisher,
     ISlackTeamRepository slackTeamRepo,
-    ILogger<PriceChangeHandler> logger)
+    ILogger<SlackPriceChangeHandler> logger)
     : IConsumer<PlayersPriceChanged>, IConsumer<PublishPriceChangesToSlackWorkspace>
 {
     public async Task Consume(ConsumeContext<PlayersPriceChanged> context)

--- a/src/FplBot/Services/WebApi/Pages/Admin/TeamDetails/PublishEvent.cshtml.cs
+++ b/src/FplBot/Services/WebApi/Pages/Admin/TeamDetails/PublishEvent.cshtml.cs
@@ -45,7 +45,7 @@ public class PublishEvent : PageModel
             var gameweek = settings!.Gameweeks.GetCurrentGameweek();
             if (team.FplbotLeagueId.HasValue && !string.IsNullOrEmpty(team.FplBotSlackChannel))
             {
-                var endpoint = await _sendEndpointProvider.GetSendEndpoint(new Uri("queue:FplBot.EventHandlers.Slack"));
+                var endpoint = await _sendEndpointProvider.GetSendEndpoint(new Uri("queue:gameweekfinishedhandler"));
                 await endpoint.Send(new PublishStandingsToSlackWorkspace(team.TeamId ?? "", team.FplBotSlackChannel ?? "", team.FplbotLeagueId.Value, gameweek!.Id));
                 TempData["msg"] = $"Published standings to {teamId}";
             }


### PR DESCRIPTION
## Summary
- Renamed 20 handler classes (10 Discord, 10 Slack) to include their platform prefix — MassTransit derives ASB queue names from the class name, so shared names meant shared queues. Discord and Slack now each get their own queue per handler type.
- Removed the 20 `using` aliases from `EventHandlersService.cs` that existed only to disambiguate the name collisions.
- Fixed two stale logger type args that were copy-paste bugs (`DiscordFixtureFulltimeHandler` used `ILogger<NearDeadlineHandler>`, `DiscordNewPlayersHandler` used `ILogger<InjuryUpdateHandler>`).
- Fixed admin `PublishEvent` page to send to `queue:gameweekfinishedhandler` instead of the old NServiceBus endpoint name `queue:FplBot.EventHandlers.Slack`.

## Test plan
- [x] CI passes
- [x] Heroku test logs clean after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)