### PR TITLE
fix: include wwwroot static assets in dotnet publish output

### DIFF
--- a/src/FplBot/FplBot.csproj
+++ b/src/FplBot/FplBot.csproj
@@ -54,13 +54,9 @@
     <Folder Include="Integrations\" />
   </ItemGroup>
 
-  <Target Name="CopyWwwrootToOutput" AfterTargets="Build">
-    <ItemGroup>
-      <_WwwRootFiles Include="$(MSBuildProjectDirectory)/Services/WebApi/wwwroot/**/*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_WwwRootFiles)"
-          DestinationFiles="@(_WwwRootFiles->'$(OutputPath)Services/WebApi/wwwroot/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
-  </Target>
+  <ItemGroup>
+    <Content Remove="Services/WebApi/wwwroot/**/*" />
+    <Content Include="Services/WebApi/wwwroot/**/*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- The custom `CopyWwwrootToOutput` MSBuild target only fired `AfterTargets="Build"`, meaning `dotnet publish` (used in Docker/Heroku) never copied the 63 wwwroot files to the publish output directory
- Replaced with `Content Remove` + `Content Include` with `CopyToPublishDirectory="PreserveNewest"`, which is the idiomatic fix for `Microsoft.NET.Sdk.Web` projects with a non-standard wwwroot location

## Test plan
- [x] CI passes
- [x] Heroku test logs clean after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)