### PR TITLE
fix: restore per-install Slack notification lost in 2026 Revamp

### DIFF
--- a/src/FplBot/FplBot.csproj
+++ b/src/FplBot/FplBot.csproj
@@ -54,13 +54,9 @@
     <Folder Include="Integrations\" />
   </ItemGroup>
 
-  <Target Name="CopyWwwrootToOutput" AfterTargets="Build">
-    <ItemGroup>
-      <_WwwRootFiles Include="$(MSBuildProjectDirectory)/Services/WebApi/wwwroot/**/*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_WwwRootFiles)"
-          DestinationFiles="@(_WwwRootFiles->'$(OutputPath)Services/WebApi/wwwroot/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
-  </Target>
+  <ItemGroup>
+    <Content Remove="Services/WebApi/wwwroot/**/*" />
+    <Content Include="Services/WebApi/wwwroot/**/*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
 
 </Project>

--- a/src/FplBot/Services/EventHandlers/AppInstalledHandler.cs
+++ b/src/FplBot/Services/EventHandlers/AppInstalledHandler.cs
@@ -29,19 +29,23 @@ public class AppInstalledHandler(IGuildRepository guildRepo,
             _ => null
         };
 
+        var definition = context.Message.Platform == ChatPlatform.Discord ? "Discord guild" : "Slack workspace";
+        var installMsg = $"🎉 A new {definition} ('{context.Message.TeamName}') installed @fplbot!";
+
+        var token = config.GetValue<string>("SlackToken_FplBot_Workspace");
+        var env = config.GetValue<string>("DOTNET_ENVIRONMENT");
+        var prefix = env == "Production" ? "" : $"{env}: ";
+        var client = builder.Build(token);
+        await client.ChatPostMessage("#fplbot-notifications", $"{prefix}{installMsg}");
+
         if (text is not null)
         {
             logger.LogInformation("Sending count msg. {Count} {Platform} installs", count, context.Message.Platform);
-
-            var token = config.GetValue<string>("SlackToken_FplBot_Workspace");
-            var env = config.GetValue<string>("DOTNET_ENVIRONMENT");
-            var prefix = env == "Production" ? "" : $"{env}: ";
-            var client = builder.Build(token);
             await client.ChatPostMessage("#fplbot-notifications", $"{prefix}{text}");
         }
         else
         {
-            logger.LogInformation("No message sent for {Platform} install. Count is {Count}", context.Message.Platform, count);
+            logger.LogInformation("No count msg for {Platform} install. Count is {Count}", context.Message.Platform, count);
         }
     }
 }

--- a/src/FplBot/Services/EventHandlers/AppInstalledHandler.cs
+++ b/src/FplBot/Services/EventHandlers/AppInstalledHandler.cs
@@ -31,21 +31,17 @@ public class AppInstalledHandler(IGuildRepository guildRepo,
 
         var definition = context.Message.Platform == ChatPlatform.Discord ? "Discord guild" : "Slack workspace";
         var installMsg = $"🎉 A new {definition} ('{context.Message.TeamName}') installed @fplbot!";
+        var fullMsg = text is not null ? $"{installMsg} {text}" : installMsg;
+
+        if (text is not null)
+            logger.LogInformation("Sending count msg. {Count} {Platform} installs", count, context.Message.Platform);
+        else
+            logger.LogInformation("No count msg for {Platform} install. Count is {Count}", context.Message.Platform, count);
 
         var token = config.GetValue<string>("SlackToken_FplBot_Workspace");
         var env = config.GetValue<string>("DOTNET_ENVIRONMENT");
         var prefix = env == "Production" ? "" : $"{env}: ";
         var client = builder.Build(token);
-        await client.ChatPostMessage("#fplbot-notifications", $"{prefix}{installMsg}");
-
-        if (text is not null)
-        {
-            logger.LogInformation("Sending count msg. {Count} {Platform} installs", count, context.Message.Platform);
-            await client.ChatPostMessage("#fplbot-notifications", $"{prefix}{text}");
-        }
-        else
-        {
-            logger.LogInformation("No count msg for {Platform} install. Count is {Count}", context.Message.Platform, count);
-        }
+        await client.ChatPostMessage("#fplbot-notifications", $"{prefix}{fullMsg}");
     }
 }


### PR DESCRIPTION
## Summary
- Restores the per-install notification (`🎉 A new Discord guild ('X') installed @fplbot!`) that was in `AuditHandler` in the deleted Azure Functions project
- The uninstall side was ported when Functions were removed; the install side was not
- On a milestone install, both sentences are combined into one message: `🎉 A new Discord guild ('X') installed @fplbot! 💯1900 Discord installs!`

## Test plan
- [x] CI passes
- [x] Heroku test logs clean after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)