### PR TITLE
Generate release notes with GitHub Copilot

### DIFF
--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -15,6 +15,17 @@ welcome as seasoning, but the primary flavor must be genuine **Fantasy
 Premier League** mechanics — gameweeks, deadlines, transfers, price
 changes, chips, captaincy, bonus points, autosubs, rank.
 
+**If a "Live FPL Context" section appears further down this document,
+using it is MANDATORY, not optional flavor.** You MUST work in at least
+one real, specific fact from it somewhere in the gameweek review — an
+actual fixture scoreline, an actual goalscorer, or one of the actual top
+gameweek point-scorers listed there. This is a hard requirement with the
+same priority as the roast rule and the assist rule below, not something
+to drop when the entries get busy. Never invent a stat, score, or player
+performance that isn't literally present in that section — only use what
+it actually gives you. If no "Live FPL Context" section is present at
+all, skip this requirement silently.
+
 ### Categories
 
 There are three semantic buckets: **new stuff**, **fixes**, and

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -55,27 +55,46 @@ entirely, just kept out of the commentary.)
 - Describe the feature/fix/change AS IF it were a player, a tactical
   switch, or a moment in a match — but the actual behavior described must
   still be accurate and understandable underneath the bit.
+- **The metaphor is seasoning, not the substance.** Every entry MUST make
+  it unambiguously clear, in plain terms, what actually changed and what
+  the admin will now see or no longer see — a reader must not have to
+  already know what the bug/feature was to understand the entry. If you
+  had to strip out every football word, a factual sentence describing the
+  real behavior change should still be sitting there underneath. Never
+  write an entry that is pure atmosphere with no recoverable fact in it
+  (e.g. "went missing in the tunnel" on its own is NOT enough — say what
+  went missing, when, and what happens differently now that it's fixed).
+- Concrete beats vague: name the actual notification/command/setting
+  affected and the actual before/after behavior, not just "a niggle" or
+  "some tweaks".
 - Do NOT invent or reference real, named footballers (living or
   retired) — use generic archetypes only ("the new striker", "the
   veteran centre-back", "the super-sub"), never a real person's name.
 - Use present tense: "Add", "Fix", "Show" — commentary is happening live.
-- Keep each entry to one or two sentences, punchy, like a commentary
-  soundbite, not a paragraph.
+- One to three sentences per entry — long enough to actually explain the
+  change, short enough to still read like a commentary soundbite, not a
+  press release.
 - No PR numbers or author attribution in this part.
 
 ### Example Entries
 
 - `### ⚽ New Signings`
-  - Deadline reminders just got a new striker up top — you'll hear from
-    them earlier, and they don't miss a chance to remind you before the
-    whistle blows.
+  - New striker up top: deadline reminders now fire a full hour before
+    the transfer window shuts, not just 15 minutes before — no more
+    getting caught cold at the death.
 - `### 🩹 Treatment Room`
-  - The captaincy alert had picked up a knock and was going missing at
-    kick-off — the physio's had a look, and it's back on the teamsheet
-    for every gameweek now.
+  - The captaincy alert had been going missing whenever a workspace
+    uninstalled and reinstalled the bot — no reminder would fire at all
+    for that team. Physio's sorted it: the alert is back on the
+    teamsheet and fires every gameweek again, reinstall or not.
 - `### 🎯 Tactical Tweaks`
-  - Price change notifications switched formation — tighter at the back,
-    fewer needless final-third giveaways, same clinical finish.
+  - Price change notifications used to batch every player rise/fall
+    into one wall-of-text message. Tighter shape now — one clean line
+    per player, same info, way less scrolling to find your guy.
+
+Note how each example names the exact notification/command affected and
+the precise before → after behavior — the football flourish decorates
+that fact, it doesn't substitute for it.
 
 ---
 

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -39,6 +39,21 @@ Do not generate commentary entries for:
 (These are still fair game for Part 2 below — never silently dropped
 entirely, just kept out of the commentary.)
 
+### The Goalless Draw
+
+If, after applying the skip list above, there are **zero** entries across
+all three categories (i.e. the release is nothing but chores, CI,
+refactors, dependency bumps, etc.) — do NOT print any of the three
+category headings. Instead write a short, genuinely funny "nothing to
+see here" blurb, framed as commentary on a dreadful 0-0 draw: openly
+mock how uneventful the match was, lean into pundit disappointment
+("we were promised fireworks, we got a testimonial"), and be honest that
+this release is all backstage/pitch-maintenance work with nothing new
+for admins to notice matchday-side. Keep it to 2-4 sentences, still
+funny, still football-mad — this is the one place atmosphere-over-
+substance is fine, since the honest fact IS "nothing user-facing
+changed", so say that plainly somewhere in the blurb.
+
 ### Style — lay it on thick
 
 - Write for a non-technical Slack/Discord admin, not a developer. No
@@ -101,11 +116,11 @@ that fact, it doesn't substitute for it.
 
 ---
 
-## Part 2 — the match report (for developers)
+## Part 2 — the detailed match report (for developers)
 
-A separate, plain, precise, technical section under a `### 📋 Match
-Report` heading, aimed at engineers reading this on GitHub. No football
-bits here — just facts.
+A separate, plain, precise, technical section under a `### 📋 Detailed
+Match Report` heading, aimed at engineers reading this on GitHub. No
+football bits here — just facts.
 
 - Include **every** merged PR, with nothing skipped — including CI/CD,
   dependency bumps, refactors, and internal tooling changes that Part 1

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -23,8 +23,21 @@ gameweek point-scorers listed there. This is a hard requirement with the
 same priority as the roast rule and the assist rule below, not something
 to drop when the entries get busy. Never invent a stat, score, or player
 performance that isn't literally present in that section — only use what
-it actually gives you. If no "Live FPL Context" section is present at
-all, skip this requirement silently.
+it actually gives you.
+
+**Do not combine two separate real facts into one invented scene.** Each
+fact in that section belongs to a specific fixture/line — if you cite
+two players, they must be from the SAME line of that section (same
+fixture, or both from the same "top scorers" list treated as a list, not
+merged into a fake shared moment). E.g. if the section shows "Player A"
+scored in Fixture 1 and "Player B" scored in Fixture 2, do NOT write a
+sentence implying they were on the pitch together or in the same match —
+that fixture never happened. When in doubt, cite exactly one player or
+one fixture, verbatim, rather than blending two real things into a
+plausible-sounding but fabricated combination.
+
+If no "Live FPL Context" section is present at all, skip this
+requirement silently.
 
 ### Categories
 

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -1,16 +1,19 @@
 # Release Notes Style Guide
 
-FplBot is a Fantasy Premier League chatbot for Slack and Discord. The
-audience for these notes is workspace/guild admins who installed the bot —
-not developers. Write for them, and write it **football-mad**: every entry
-should sound like a matchday commentator lost the plot describing a
-changelog. Silly football clichés and metaphors are not just allowed, they
-are mandatory.
+FplBot is a Fantasy Premier League chatbot for Slack and Discord. Produce
+release notes in **two parts**, always both, in this order.
 
-## Categories
+## Part 1 — the matchday commentary (for admins, football-mad)
 
-Group entries under these headings, in this order. Omit a heading entirely
-if it has no entries.
+A human, non-technical summary for the workspace/guild admins who
+installed the bot. Write it **football-mad**: every entry should sound
+like a matchday commentator lost the plot describing a changelog. Silly
+football clichés and metaphors are not just allowed, they are mandatory.
+
+### Categories
+
+Group entries under these headings, in this order. Omit a heading
+entirely if it has no entries.
 
 - `### ⚽ New Signings` — new notification types, commands, or bot features
 - `### 🩹 Treatment Room` — bug fixes (describe the user-visible symptom
@@ -20,9 +23,9 @@ if it has no entries.
   features or bug fixes (formation changes, a bit of extra pace, sharper
   finishing)
 
-## What to Skip
+### What to Skip (this part only)
 
-Do not generate entries for:
+Do not generate commentary entries for:
 - CI/CD, build, Dockerfile, or deployment pipeline changes
 - Dependency/package bumps, unless they fix a security vulnerability or a
   user-visible bug
@@ -30,7 +33,10 @@ Do not generate entries for:
   change
 - Changes to internal docs, CLAUDE.md, or repo tooling
 
-## Style — lay it on thick
+(These are still fair game for Part 2 below — never silently dropped
+entirely, just kept out of the commentary.)
+
+### Style — lay it on thick
 
 - Write for a non-technical Slack/Discord admin, not a developer. No
   jargon ("consumer", "handler", "MassTransit", "Redis", etc.) — ever.
@@ -55,13 +61,9 @@ Do not generate entries for:
 - Use present tense: "Add", "Fix", "Show" — commentary is happening live.
 - Keep each entry to one or two sentences, punchy, like a commentary
   soundbite, not a paragraph.
+- No PR numbers or author attribution in this part.
 
-## Entry Format
-
-`<description>` — no PR numbers or author attribution, this is a
-matchday-style changelog, not a dev changelog.
-
-## Example Entries
+### Example Entries
 
 - `### ⚽ New Signings`
   - Deadline reminders just got a new striker up top — you'll hear from
@@ -74,3 +76,24 @@ matchday-style changelog, not a dev changelog.
 - `### 🎯 Tactical Tweaks`
   - Price change notifications switched formation — tighter at the back,
     fewer needless final-third giveaways, same clinical finish.
+
+---
+
+## Part 2 — the match report (for developers)
+
+A separate, plain, precise, technical section under a `### 📋 Match
+Report` heading, aimed at engineers reading this on GitHub. No football
+bits here — just facts.
+
+- Include **every** merged PR, with nothing skipped — including CI/CD,
+  dependency bumps, refactors, and internal tooling changes that Part 1
+  leaves out.
+- One line per PR: `<concise technical description> (#<pr_number>) by
+  @<author>`
+- Group as a flat list, or under `Fixes` / `Features` / `Chores` /
+  `Dependencies` sub-bullets if there are more than ~8 entries — whichever
+  is more scannable.
+- Use normal engineering language here (consumer, handler, endpoint,
+  dependency name, etc. are all fine) — this part is for developers, be
+  precise rather than cute.
+- Keep each line short — this is a scan-and-click reference, not prose.

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -1,0 +1,39 @@
+# Release Notes Style Guide
+
+FplBot is a Fantasy Premier League chatbot for Slack and Discord. The
+audience for these notes is workspace/guild admins who installed the bot —
+not developers. Write for them.
+
+## Categories
+
+Group entries under these headings, in this order. Omit a heading entirely
+if it has no entries.
+
+- `### ✨ New` — new notification types, commands, or bot features
+- `### 🐛 Fixed` — bug fixes (describe the user-visible symptom that's gone)
+- `### 🔧 Improved` — changes to existing behavior that aren't new features
+  or bug fixes (e.g. better formatting, faster updates)
+
+## What to Skip
+
+Do not generate entries for:
+- CI/CD, build, Dockerfile, or deployment pipeline changes
+- Dependency/package bumps, unless they fix a security vulnerability or a
+  user-visible bug
+- Test-only changes, refactors, or internal code cleanup with no behavior
+  change
+- Changes to internal docs, CLAUDE.md, or repo tooling
+
+## Style
+
+- Write for a non-technical Slack/Discord admin, not a developer
+- Use present tense: "Add", "Fix", "Show"
+- Talk about what the bot does differently, not which class/file changed
+- One line per entry, plain language, no jargon (no "consumer", "handler",
+  "MassTransit", "Redis", etc.)
+- Keep each entry under ~100 characters where possible
+
+## Entry Format
+
+`<description>` — no PR numbers or author attribution needed, this is a
+user-facing changelog, not a dev changelog.

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -12,8 +12,11 @@ football clichés and metaphors are not just allowed, they are mandatory.
 
 ### Categories
 
-Group entries under these headings, in this order. Omit a heading
-entirely if it has no entries.
+Group entries under these headings, in this order. If a category has no
+entries, delete its heading line completely — do not print the heading
+with a placeholder like "(none this window)", "N/A", or an empty bullet.
+A heading with zero entries under it should not appear in the output at
+all.
 
 - `### ⚽ New Signings` — new notification types, commands, or bot features
 - `### 🩹 Treatment Room` — bug fixes (describe the user-visible symptom

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -118,16 +118,33 @@ three handles is an external contributor.
   the word assist — reserve "goal"/"strike"/scoring language for them,
   "assist" specifically for external contributors. This distinction must
   be visibly, unmistakably present in the text whenever it applies.
-- **Mandatory, not optional:** at least once per gameweek review (doesn't
-  need to be every entry), gently rib whoever's name is on a PR —
-  maintainer or contributor — about being a coder instead of an actual
-  Premier League player: wish them Prem wages for this commit, joke they
-  missed their calling as a £250k-a-week midfielder instead of fixing a
-  Slack handler, etc. Keep it affectionate, about the money/fame gap
-  only, never actually questioning their skill or code quality. Naming
-  their real GitHub handle for this specific joke is required, not just
+- **Mandatory, not optional, EVERY single entry in 🃏/⭐/etc. and 🩹/etc.
+  categories (skip only the 📊/polish category if you want, that one's
+  optional):** every entry must end with a dedicated roast sentence
+  mocking that PR's real author (`@handle`) for being a coder instead of
+  an actual Premier League player earning actual Premier League money.
+  This is a genuine mock, not a compliment wearing a joke's costume —
+  do NOT let it turn into secretly praising their skills ("reflexes like
+  that" / "sharp eye" / "nice bit of business" is BANNED, that's a
+  compliment, not a roast). Actually make fun of them: their wages, their
+  Tuesday-night five-a-side instead of the San Siro, their FPL rank
+  probably being worse than their code, the fact that fixing a Slack
+  handler is the closest they'll ever get to a man-of-the-match award.
+  Some tones to use, vary it:
+  - "@handle out here fixing race conditions for a normal salary while
+    some bang-average Championship right-back earns more in a
+    Tuesday training session"
+  - "@handle's idea of 'squeaky bum time' is a failing CI pipeline, not
+    a cup final — imagine peaking at 5-a-side on Tuesdays"
+  - "somewhere a Prem scout is NOT calling @handle, and honestly, fair"
+  - "@handle really shipped this thinking it's the same as scoring at
+    the Etihad — it is not, @handle, it is not"
+  - "if effort translated to wages @handle would be on Haaland money;
+    instead, enjoy your Jira ticket"
+  Naming their real GitHub handle for this joke is required, not just
   allowed — that's the one exception to "no author attribution in this
-  part." If a gameweek review has no such line in it, it's incomplete.
+  part." An entry with no mocking line at the end is incomplete and must
+  be rewritten before output.
 
 ### Style — lay it on thick, FPL-first
 

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -2,17 +2,23 @@
 
 FplBot is a Fantasy Premier League chatbot for Slack and Discord. The
 audience for these notes is workspace/guild admins who installed the bot —
-not developers. Write for them.
+not developers. Write for them, and write it **football-mad**: every entry
+should sound like a matchday commentator lost the plot describing a
+changelog. Silly football clichés and metaphors are not just allowed, they
+are mandatory.
 
 ## Categories
 
 Group entries under these headings, in this order. Omit a heading entirely
 if it has no entries.
 
-- `### ✨ New` — new notification types, commands, or bot features
-- `### 🐛 Fixed` — bug fixes (describe the user-visible symptom that's gone)
-- `### 🔧 Improved` — changes to existing behavior that aren't new features
-  or bug fixes (e.g. better formatting, faster updates)
+- `### ⚽ New Signings` — new notification types, commands, or bot features
+- `### 🩹 Treatment Room` — bug fixes (describe the user-visible symptom
+  that's gone, framed as a player coming back from injury / a niggle
+  being sorted by the physio)
+- `### 🎯 Tactical Tweaks` — changes to existing behavior that aren't new
+  features or bug fixes (formation changes, a bit of extra pace, sharper
+  finishing)
 
 ## What to Skip
 
@@ -24,16 +30,47 @@ Do not generate entries for:
   change
 - Changes to internal docs, CLAUDE.md, or repo tooling
 
-## Style
+## Style — lay it on thick
 
-- Write for a non-technical Slack/Discord admin, not a developer
-- Use present tense: "Add", "Fix", "Show"
-- Talk about what the bot does differently, not which class/file changed
-- One line per entry, plain language, no jargon (no "consumer", "handler",
-  "MassTransit", "Redis", etc.)
-- Keep each entry under ~100 characters where possible
+- Write for a non-technical Slack/Discord admin, not a developer. No
+  jargon ("consumer", "handler", "MassTransit", "Redis", etc.) — ever.
+- Every single entry must use at least one football commentary cliché or
+  metaphor. Draw from things pundits and fans actually say, e.g.:
+  - "an absolute worldie", "top bins", "back of the net", "onion bag"
+  - "over the moon" / "sick as a parrot"
+  - "squeaky bum time", "smash and grab", "park the bus"
+  - "game of two halves", "early doors", "Fergie time", "at the death"
+  - "a masterclass", "world-class", "won the game in the tunnel"
+  - "row Z", "hospital pass", "handbags", "the dark arts"
+  - "a rock at the back", "pulling the strings in midfield", "a poacher's
+    instinct", "the engine room", "wonderkid", "super-sub off the bench"
+  - "clean sheet", "banging them in for fun", "not at the races",
+    "dead rubber", "relegation form", "title-winning"
+- Describe the feature/fix/change AS IF it were a player, a tactical
+  switch, or a moment in a match — but the actual behavior described must
+  still be accurate and understandable underneath the bit.
+- Do NOT invent or reference real, named footballers (living or
+  retired) — use generic archetypes only ("the new striker", "the
+  veteran centre-back", "the super-sub"), never a real person's name.
+- Use present tense: "Add", "Fix", "Show" — commentary is happening live.
+- Keep each entry to one or two sentences, punchy, like a commentary
+  soundbite, not a paragraph.
 
 ## Entry Format
 
-`<description>` — no PR numbers or author attribution needed, this is a
-user-facing changelog, not a dev changelog.
+`<description>` — no PR numbers or author attribution, this is a
+matchday-style changelog, not a dev changelog.
+
+## Example Entries
+
+- `### ⚽ New Signings`
+  - Deadline reminders just got a new striker up top — you'll hear from
+    them earlier, and they don't miss a chance to remind you before the
+    whistle blows.
+- `### 🩹 Treatment Room`
+  - The captaincy alert had picked up a knock and was going missing at
+    kick-off — the physio's had a look, and it's back on the teamsheet
+    for every gameweek now.
+- `### 🎯 Tactical Tweaks`
+  - Price change notifications switched formation — tighter at the back,
+    fewer needless final-third giveaways, same clinical finish.

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -3,12 +3,17 @@
 FplBot is a Fantasy Premier League chatbot for Slack and Discord. Produce
 release notes in **two parts**, always both, in this order.
 
-## Part 1 — the matchday commentary (for admins, football-mad)
+## Part 1 — the gameweek review (for admins, FPL-mad)
 
 A human, non-technical summary for the workspace/guild admins who
-installed the bot. Write it **football-mad**: every entry should sound
-like a matchday commentator lost the plot describing a changelog. Silly
-football clichés and metaphors are not just allowed, they are mandatory.
+installed the bot, written for an FPL manager, not a generic football
+fan. Treat this release as a **gameweek**: features are transfers and
+chip plays, fixes are players returning from the treatment room in time
+for the deadline, and small improvements are the extra bonus points
+handed out once the BPS dust settles. Football commentary clichés are
+welcome as seasoning, but the primary flavor must be genuine **Fantasy
+Premier League** mechanics — gameweeks, deadlines, transfers, price
+changes, chips, captaincy, bonus points, autosubs, rank.
 
 ### Categories
 
@@ -18,13 +23,19 @@ with a placeholder like "(none this window)", "N/A", or an empty bullet.
 A heading with zero entries under it should not appear in the output at
 all.
 
-- `### ⚽ New Signings` — new notification types, commands, or bot features
-- `### 🩹 Treatment Room` — bug fixes (describe the user-visible symptom
-  that's gone, framed as a player coming back from injury / a niggle
-  being sorted by the physio)
-- `### 🎯 Tactical Tweaks` — changes to existing behavior that aren't new
-  features or bug fixes (formation changes, a bit of extra pace, sharper
-  finishing)
+- `### 🃏 Chip Plays` — new notification types, commands, or bot
+  features. Frame the size of the change as the chip being played:
+  a small addition is a straightforward **transfer in**; a genuinely big
+  new feature gets to be a **Wildcard** (full overhaul) or **Bench
+  Boost** (more of the squad now contributing); a temporary/experimental
+  feature can be a **Free Hit**.
+- `### 🩹 Treatment Room` — bug fixes. Frame as a player who picked up a
+  knock and is now back on the teamsheet, ideally back **before the
+  deadline** rather than being a late fitness doubt.
+- `### 📊 Bonus Points` — changes to existing behavior that aren't new
+  features or bug fixes — polish, performance, formatting. Frame as the
+  BPS system quietly handing out extra points after the match: nothing
+  new happened on the pitch, it just counts for more / reads better now.
 
 ### What to Skip (this part only)
 
@@ -39,55 +50,62 @@ Do not generate commentary entries for:
 (These are still fair game for Part 2 below — never silently dropped
 entirely, just kept out of the commentary.)
 
-### The Goalless Draw
+### The Blank Gameweek
 
 If, after applying the skip list above, there are **zero** entries across
 all three categories (i.e. the release is nothing but chores, CI,
 refactors, dependency bumps, etc.) — do NOT print any of the three
 category headings. Instead write a short, genuinely funny "nothing to
-see here" blurb, framed as commentary on a dreadful 0-0 draw: openly
-mock how uneventful the match was, lean into pundit disappointment
-("we were promised fireworks, we got a testimonial"), and be honest that
-this release is all backstage/pitch-maintenance work with nothing new
-for admins to notice matchday-side. Keep it to 2-4 sentences, still
-funny, still football-mad — this is the one place atmosphere-over-
-substance is fine, since the honest fact IS "nothing user-facing
+see here" blurb, framed as an FPL **blank gameweek**: the fixture
+computer left this one empty, every one of your players is on a bye, 0-0
+snorefest, no points on the board either way. Lean into pundit/manager
+disappointment ("we were promised a double gameweek, we got a bye
+week"), and be honest that this release is all backstage/pitch-
+maintenance work with nothing new for admins to notice on the teamsheet.
+Keep it to 2-4 sentences, still funny — this is the one place atmosphere
+-over-substance is fine, since the honest fact IS "nothing user-facing
 changed", so say that plainly somewhere in the blurb.
 
-### Style — lay it on thick
+### Style — lay it on thick, FPL-first
 
-- Write for a non-technical Slack/Discord admin, not a developer. No
-  jargon ("consumer", "handler", "MassTransit", "Redis", etc.) — ever.
-- Every single entry must use at least one football commentary cliché or
-  metaphor. Draw from things pundits and fans actually say, e.g.:
-  - "an absolute worldie", "top bins", "back of the net", "onion bag"
-  - "over the moon" / "sick as a parrot"
-  - "squeaky bum time", "smash and grab", "park the bus"
-  - "game of two halves", "early doors", "Fergie time", "at the death"
-  - "a masterclass", "world-class", "won the game in the tunnel"
-  - "row Z", "hospital pass", "handbags", "the dark arts"
-  - "a rock at the back", "pulling the strings in midfield", "a poacher's
-    instinct", "the engine room", "wonderkid", "super-sub off the bench"
-  - "clean sheet", "banging them in for fun", "not at the races",
-    "dead rubber", "relegation form", "title-winning"
-- Describe the feature/fix/change AS IF it were a player, a tactical
-  switch, or a moment in a match — but the actual behavior described must
-  still be accurate and understandable underneath the bit.
+- Write for a non-technical Slack/Discord admin who plays FPL, not a
+  developer. No engineering jargon ("consumer", "handler",
+  "MassTransit", "Redis", etc.) — ever.
+- Every entry must use at least one genuine **FPL-specific** concept, not
+  just generic football commentary. Draw from real FPL mechanics, e.g.:
+  - gameweek, deadline, the transfer window, a free transfer vs. taking
+    a hit
+  - price rises / price falls, ownership %, a differential pick, a
+    template pick
+  - chips: Wildcard, Free Hit, Bench Boost, Triple Captain, Assistant
+    Manager
+  - captain / vice-captain, armband, blank gameweek, double gameweek,
+    autosub, rank, green arrow / red arrow
+  - bonus points (BPS), defensive contribution points, a clean sheet,
+    a returning player fit for the deadline
+- General football commentator clichés ("an absolute worldie", "top
+  bins", "squeaky bum time", "smash and grab", "at the death") are fine
+  as extra color layered on top of the FPL mechanic, not a replacement
+  for it.
+- Describe the feature/fix/change AS IF it were a transfer, a chip play,
+  or a gameweek event — but the actual behavior described must still be
+  accurate and understandable underneath the bit.
 - **The metaphor is seasoning, not the substance.** Every entry MUST make
   it unambiguously clear, in plain terms, what actually changed and what
   the admin will now see or no longer see — a reader must not have to
   already know what the bug/feature was to understand the entry. If you
-  had to strip out every football word, a factual sentence describing the
-  real behavior change should still be sitting there underneath. Never
-  write an entry that is pure atmosphere with no recoverable fact in it
-  (e.g. "went missing in the tunnel" on its own is NOT enough — say what
-  went missing, when, and what happens differently now that it's fixed).
+  had to strip out every football/FPL word, a factual sentence
+  describing the real behavior change should still be sitting there
+  underneath. Never write an entry that is pure atmosphere with no
+  recoverable fact in it (e.g. "brought on as a sub" on its own is NOT
+  enough — say what changed, when, and what happens differently now).
 - Concrete beats vague: name the actual notification/command/setting
   affected and the actual before/after behavior, not just "a niggle" or
   "some tweaks".
-- Do NOT invent or reference real, named footballers (living or
-  retired) — use generic archetypes only ("the new striker", "the
-  veteran centre-back", "the super-sub"), never a real person's name.
+- Do NOT invent or reference real, named footballers or real FPL
+  managers/content creators (living or retired) — use generic archetypes
+  only ("the new striker", "the template captain", "the differential
+  pick"), never a real person's name.
 - Use present tense: "Add", "Fix", "Show" — commentary is happening live.
 - One to three sentences per entry — long enough to actually explain the
   change, short enough to still read like a commentary soundbite, not a
@@ -96,23 +114,26 @@ changed", so say that plainly somewhere in the blurb.
 
 ### Example Entries
 
-- `### ⚽ New Signings`
-  - New striker up top: deadline reminders now fire a full hour before
-    the transfer window shuts, not just 15 minutes before — no more
-    getting caught cold at the death.
+- `### 🃏 Chip Plays`
+  - Playing the Bench Boost on deadline reminders: they now fire a full
+    hour before the transfer window shuts instead of just 15 minutes
+    before, so nobody's left making a panic transfer at the death.
 - `### 🩹 Treatment Room`
-  - The captaincy alert had been going missing whenever a workspace
-    uninstalled and reinstalled the bot — no reminder would fire at all
-    for that team. Physio's sorted it: the alert is back on the
-    teamsheet and fires every gameweek again, reinstall or not.
-- `### 🎯 Tactical Tweaks`
-  - Price change notifications used to batch every player rise/fall
-    into one wall-of-text message. Tighter shape now — one clean line
-    per player, same info, way less scrolling to find your guy.
+  - The captaincy alert had been ruled out whenever a workspace
+    uninstalled and reinstalled the bot — no armband reminder at all for
+    that team, gameweek after gameweek. Passed its late fitness test:
+    it's back reminding every team before every deadline, reinstall or
+    not.
+- `### 📊 Bonus Points`
+  - Price change notifications used to dump every rise and fall into one
+    wall-of-text message. BPS has been recalculated — one clean line per
+    player now, same green/red arrows, way less scrolling to find your
+    guy.
 
 Note how each example names the exact notification/command affected and
-the precise before → after behavior — the football flourish decorates
-that fact, it doesn't substitute for it.
+the precise before → after behavior, using a real FPL mechanic (chip
+plays, fitness tests, BPS) to carry it — the flourish decorates the
+fact, it doesn't substitute for it.
 
 ---
 
@@ -120,7 +141,7 @@ that fact, it doesn't substitute for it.
 
 A separate, plain, precise, technical section under a `### 📋 Detailed
 Match Report` heading, aimed at engineers reading this on GitHub. No
-football bits here — just facts.
+football or FPL bits here — just facts.
 
 - Include **every** merged PR, with nothing skipped — including CI/CD,
   dependency bumps, refactors, and internal tooling changes that Part 1

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -17,25 +17,62 @@ changes, chips, captaincy, bonus points, autosubs, rank.
 
 ### Categories
 
-Group entries under these headings, in this order. If a category has no
-entries, delete its heading line completely — do not print the heading
-with a placeholder like "(none this window)", "N/A", or an empty bullet.
-A heading with zero entries under it should not appear in the output at
-all.
+There are three semantic buckets: **new stuff**, **fixes**, and
+**polish**. Every release note entry belongs to exactly one of them. But
+the heading text for each bucket is NOT fixed — every time you generate
+notes, randomly pick a *different* heading (with its emoji) from that
+bucket's pool below, so headings vary release to release instead of
+being identical every time. Don't default to the first option in the
+list — actually vary your pick.
 
-- `### 🃏 Chip Plays` — new notification types, commands, or bot
-  features. Frame the size of the change as the chip being played:
-  a small addition is a straightforward **transfer in**; a genuinely big
-  new feature gets to be a **Wildcard** (full overhaul) or **Bench
-  Boost** (more of the squad now contributing); a temporary/experimental
-  feature can be a **Free Hit**.
-- `### 🩹 Treatment Room` — bug fixes. Frame as a player who picked up a
-  knock and is now back on the teamsheet, ideally back **before the
-  deadline** rather than being a late fitness doubt.
-- `### 📊 Bonus Points` — changes to existing behavior that aren't new
-  features or bug fixes — polish, performance, formatting. Frame as the
-  BPS system quietly handing out extra points after the match: nothing
-  new happened on the pitch, it just counts for more / reads better now.
+Association football (soccer) and genuine FPL terms only. **Never**
+American football terms (no "touchdown", "quarterback", "first down",
+"blitz", "Hail Mary", "end zone", "gridiron", etc.) — this bot is about
+the Premier League, not the NFL.
+
+If a category has no entries, delete its heading line completely — do
+not print the heading with a placeholder like "(none this window)",
+"N/A", or an empty bullet. A heading with zero entries under it should
+not appear in the output at all.
+
+**New stuff** — new notification types, commands, or bot features. Pick
+one heading at random:
+- `### 🃏 Chip Plays`
+- `### ⭐ New Signings`
+- `### 🔄 Done Deals`
+- `### 📝 Squad Additions`
+- `### 🎯 Fresh Off The Bench`
+- `### 🚀 New Boots`
+
+Frame the size of the change as the transfer/chip being played: a small
+addition is a straightforward **transfer in**; a genuinely big new
+feature gets to be a **Wildcard** (full overhaul) or **Bench Boost**
+(more of the squad now contributing); a temporary/experimental feature
+can be a **Free Hit**.
+
+**Fixes** — bug fixes. Pick one heading at random:
+- `### 🩹 Treatment Room`
+- `### 🚑 Back From Injury`
+- `### 🏥 Fitness Update`
+- `### ✅ Passed The Late Fitness Test`
+- `### 🔧 Patched Up`
+
+Frame as a player who picked up a knock and is now back on the
+teamsheet, ideally back **before the deadline** rather than being a late
+fitness doubt.
+
+**Polish** — changes to existing behavior that aren't new features or
+bug fixes: performance, formatting, small improvements. Pick one heading
+at random:
+- `### 📊 Bonus Points`
+- `### 🎯 Tactical Tweaks`
+- `### 🔁 Squad Rotation`
+- `### 📈 Marginal Gains`
+- `### 🧹 Half-Time Team Talk`
+
+Frame as the BPS system quietly handing out extra points after the
+match, or a tactical tweak from the touchline: nothing new happened on
+the pitch, it just counts for more / reads better / runs smoother now.
 
 ### What to Skip (this part only)
 
@@ -65,6 +102,32 @@ maintenance work with nothing new for admins to notice on the teamsheet.
 Keep it to 2-4 sentences, still funny — this is the one place atmosphere
 -over-substance is fine, since the honest fact IS "nothing user-facing
 changed", so say that plainly somewhere in the blurb.
+
+### Crediting Contributors
+
+The active core maintainers are **@johnkors**, **@skjelbek**, and
+**@kristianeaw** — nobody else. Any PR author who is NOT one of those
+three handles is an external contributor.
+
+- **Mandatory, not optional:** if ANY entry in this release comes from
+  an external contributor (author not in the maintainer list above), that
+  specific entry's sentence MUST literally use the word "assist"
+  somewhere in it (e.g. "assist from @handle", "picks up the assist",
+  "gets the assist for this one") — not just vaguer language like
+  "reinforcement" or "loan signing". A maintainer's entry should NOT use
+  the word assist — reserve "goal"/"strike"/scoring language for them,
+  "assist" specifically for external contributors. This distinction must
+  be visibly, unmistakably present in the text whenever it applies.
+- **Mandatory, not optional:** at least once per gameweek review (doesn't
+  need to be every entry), gently rib whoever's name is on a PR —
+  maintainer or contributor — about being a coder instead of an actual
+  Premier League player: wish them Prem wages for this commit, joke they
+  missed their calling as a £250k-a-week midfielder instead of fixing a
+  Slack handler, etc. Keep it affectionate, about the money/fame gap
+  only, never actually questioning their skill or code quality. Naming
+  their real GitHub handle for this specific joke is required, not just
+  allowed — that's the one exception to "no author attribution in this
+  part." If a gameweek review has no such line in it, it's incomplete.
 
 ### Style — lay it on thick, FPL-first
 

--- a/.github/scripts/build-release-notes-context.py
+++ b/.github/scripts/build-release-notes-context.py
@@ -1,0 +1,53 @@
+import json, sys, urllib.request
+
+def fetch(url):
+    with urllib.request.urlopen(url, timeout=10) as r:
+        return json.load(r)
+
+try:
+    bootstrap = fetch("https://fantasy.premierleague.com/api/bootstrap-static/")
+    events = bootstrap['events']
+    cur = next((e for e in events if e['is_current']), None) or next((e for e in reversed(events) if e['finished']), None)
+    nxt = next((e for e in events if e['is_next']), None)
+    teams = {t['id']: t['name'] for t in bootstrap['teams']}
+    players = {p['id']: p for p in bootstrap['elements']}
+
+    lines = ["", "## Live FPL Context (real, current data — use naturally where relevant, don't force it into every entry, and don't fabricate stats not listed here)", ""]
+    if cur:
+        lines.append(f"Current: GW{cur['id']} ({cur['name']}) - finished: {cur['finished']}, average score: {cur['average_entry_score']}, highest score: {cur['highest_score']}")
+    if nxt:
+        lines.append(f"Next: GW{nxt['id']} ({nxt['name']}) - deadline: {nxt['deadline_time']}")
+
+    if cur and cur['finished']:
+        fixtures = fetch(f"https://fantasy.premierleague.com/api/fixtures/?event={cur['id']}")
+        lines.append("")
+        lines.append(f"GW{cur['id']} results:")
+        for fx in fixtures:
+            if not fx['finished']:
+                continue
+            h, a = teams[fx['team_h']], teams[fx['team_a']]
+            score = f"{h} {fx['team_h_score']}-{fx['team_a_score']} {a}"
+            scorers = []
+            for stat in fx['stats']:
+                if stat['identifier'] == 'goals_scored':
+                    for side in ('h', 'a'):
+                        for g in stat[side]:
+                            name = players[g['element']]['web_name']
+                            n = f" x{g['value']}" if g['value'] > 1 else ""
+                            scorers.append(f"{name}{n}")
+            if scorers:
+                lines.append(f"- {score} (goals: {', '.join(scorers)})")
+            else:
+                lines.append(f"- {score}")
+
+        live = fetch(f"https://fantasy.premierleague.com/api/event/{cur['id']}/live/")
+        top = sorted(live['elements'], key=lambda e: e['stats']['total_points'], reverse=True)[:3]
+        lines.append("")
+        lines.append(f"Top GW{cur['id']} FPL scorers:")
+        for e in top:
+            p = players[e['id']]
+            lines.append(f"- {p['web_name']}: {e['stats']['total_points']} pts")
+
+    print('\n'.join(lines))
+except Exception as e:
+    sys.stderr.write(f"Failed to fetch live FPL context: {e}\n")

--- a/.github/scripts/build-release-notes-context.py
+++ b/.github/scripts/build-release-notes-context.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import json, sys, urllib.request
 
 def fetch(url):

--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -48,12 +48,34 @@ jobs:
         run: dotnet run --project src/Build -- deploy-prod
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_TOKEN }}
+      - name: Get previous release tag
+        id: prev_tag
+        run: echo "tag=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate release notes
+        id: notes
+        continue-on-error: true
+        if: steps.prev_tag.outputs.tag != ''
+        uses: github/copilot-release-notes@main
+        with:
+          base-ref: ${{ steps.prev_tag.outputs.tag }}
+          head-ref: ${{ github.sha }}
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Create Release
         id: create_release
         continue-on-error: true
-        run: gh release create ${{ env.VERSION }} --generate-notes
+        run: |
+          if [ -n "$NOTES" ]; then
+            printf '%s\n' "$NOTES" > release_notes.md
+            gh release create ${{ env.VERSION }} --notes-file release_notes.md
+          else
+            gh release create ${{ env.VERSION }} --generate-notes
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTES: ${{ steps.notes.outputs.release-notes }}
       - name: update deployment status
         uses: bobheadxi/deployments@v1
         if: always()

--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -54,6 +54,13 @@ jobs:
         run: echo "tag=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add live gameweek context to release notes instructions
+        id: instructions
+        if: steps.prev_tag.outputs.tag != ''
+        run: |
+          cp .github/release-notes-instructions.md "$RUNNER_TEMP/release-notes-instructions.md"
+          python3 .github/scripts/build-release-notes-context.py >> "$RUNNER_TEMP/release-notes-instructions.md" || true
+          echo "path=$RUNNER_TEMP/release-notes-instructions.md" >> "$GITHUB_OUTPUT"
       - name: Generate release notes
         id: notes
         continue-on-error: true
@@ -62,6 +69,7 @@ jobs:
         with:
           base-ref: ${{ steps.prev_tag.outputs.tag }}
           head-ref: ${{ github.sha }}
+          instructions: ${{ steps.instructions.outputs.path }}
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Create Release

--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       deployments: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/GenerateReleaseNotes.yml
+++ b/.github/workflows/GenerateReleaseNotes.yml
@@ -33,12 +33,19 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add live gameweek context to release notes instructions
+        id: instructions
+        run: |
+          cp .github/release-notes-instructions.md "$RUNNER_TEMP/release-notes-instructions.md"
+          python3 .github/scripts/build-release-notes-context.py >> "$RUNNER_TEMP/release-notes-instructions.md" || true
+          echo "path=$RUNNER_TEMP/release-notes-instructions.md" >> "$GITHUB_OUTPUT"
       - name: Generate release notes
         id: notes
         uses: github/copilot-release-notes@main
         with:
           base-ref: ${{ steps.base.outputs.ref }}
           head-ref: ${{ inputs.head-ref }}
+          instructions: ${{ steps.instructions.outputs.path }}
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Show generated notes

--- a/.github/workflows/GenerateReleaseNotes.yml
+++ b/.github/workflows/GenerateReleaseNotes.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   generate-release-notes:

--- a/.github/workflows/GenerateReleaseNotes.yml
+++ b/.github/workflows/GenerateReleaseNotes.yml
@@ -1,0 +1,52 @@
+name: generate-release-notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: "Tag/branch/SHA to compare from (defaults to the latest published release)"
+        required: false
+      head-ref:
+        description: "Tag/branch/SHA to compare to"
+        required: false
+        default: "HEAD"
+
+permissions:
+  contents: read
+
+jobs:
+  generate-release-notes:
+    name: generate-release-notes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Resolve base ref
+        id: base
+        run: |
+          if [ -n "${{ inputs.base-ref }}" ]; then
+            echo "ref=${{ inputs.base-ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate release notes
+        id: notes
+        uses: github/copilot-release-notes@main
+        with:
+          base-ref: ${{ steps.base.outputs.ref }}
+          head-ref: ${{ inputs.head-ref }}
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      - name: Show generated notes
+        run: |
+          {
+            echo "## Generated release notes"
+            echo "base-ref: ${{ steps.base.outputs.ref }}"
+            echo ""
+            echo "$NOTES"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          NOTES: ${{ steps.notes.outputs.release-notes }}


### PR DESCRIPTION
## Summary
- Replace `gh release create --generate-notes` in DeployToProd with `github/copilot-release-notes`, which summarizes merged PRs between the previous release and the new one using GitHub Copilot.
- Falls back to `--generate-notes` if there's no prior release or the Copilot action fails.
- Adds a standalone `generate-release-notes` workflow to test note generation on demand against any two tags/refs, without deploying anything.

## Requirements
- `COPILOT_GITHUB_TOKEN` repo secret (fine-grained PAT with "Copilot Requests: Read" account permission) — already added.

## Test plan
- [ ] Trigger `generate-release-notes` workflow manually with two real tags and confirm the job summary shows sensible notes
- [ ] Merge and verify the next prod deploy creates a release with Copilot-generated notes (or falls back gracefully)