### PR TITLE
Fix: pass GITHUB_TOKEN to copilot-release-notes action

### DIFF
--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -71,6 +71,7 @@ jobs:
           head-ref: ${{ github.sha }}
           instructions: ${{ steps.instructions.outputs.path }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Create Release
         id: create_release

--- a/.github/workflows/GenerateReleaseNotes.yml
+++ b/.github/workflows/GenerateReleaseNotes.yml
@@ -47,6 +47,7 @@ jobs:
           head-ref: ${{ inputs.head-ref }}
           instructions: ${{ steps.instructions.outputs.path }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Show generated notes
         run: |


### PR DESCRIPTION
## Summary
- The "Generate release notes" step in DeployToProd.yml and GenerateReleaseNotes.yml only set `COPILOT_GITHUB_TOKEN`, so the action fell back to that fine-grained PAT for PR API calls too.
- fplbot's org policy blocks fine-grained PATs with lifetime > 366 days from accessing org resources, which broke the real run just now:
  ```
  Warning: Failed to fetch PR #378: HttpError: The 'fplbot' organization forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 366 days.
  ```
- Fix: also pass `GITHUB_TOKEN` (the built-in Actions token, not subject to this policy) — the action already prefers it for PR API calls per its own design, we just never wired it up.

## Test plan
- [ ] Merge and re-run `generate-release-notes` or the next prod deploy, confirm PR metadata fetches succeed