### PR TITLE
Add top performers to the full time notification

### DIFF
--- a/src/FplBot.Tests/Formatting/FixtureFulltimeModelBuilderTests.cs
+++ b/src/FplBot.Tests/Formatting/FixtureFulltimeModelBuilderTests.cs
@@ -124,6 +124,133 @@ public class FixtureFulltimeModelBuilderTests
         Assert.Equal(30, only.BonusPoints);
     }
 
+    [Fact]
+    public void WithLiveItems_ResolvesTopPerformersOrderedByPoints()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+        var liveItems = new[]
+        {
+            TestBuilder.LiveItem(TestBuilder.PlayerId, (fixture.Id, 8)),
+            TestBuilder.LiveItem(TestBuilder.OtherPlayerId, (fixture.Id, 12))
+        };
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, PlayersWithTeams(), fixture, liveItems);
+
+        var topPerformers = finished.TopPerformers.ToList();
+        Assert.Equal(2, topPerformers.Count);
+        Assert.Equal(TestBuilder.OtherPlayerId, topPerformers[0].Player.Id);
+        Assert.Equal(12, topPerformers[0].Points);
+        Assert.Equal(TestBuilder.PlayerId, topPerformers[1].Player.Id);
+        Assert.Equal(8, topPerformers[1].Points);
+    }
+
+    [Fact]
+    public void DoubleGameweekPlayer_OnlyCountsPointsFromThisFixture()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+        var liveItems = new[] { TestBuilder.LiveItem(TestBuilder.PlayerId, (fixture.Id, 6), (999, 10)) };
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, PlayersWithTeams(), fixture, liveItems);
+
+        var only = Assert.Single(finished.TopPerformers);
+        Assert.Equal(6, only.Points);
+    }
+
+    [Fact]
+    public void PlayerWithoutExplainForThisFixture_IsExcluded()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+        var liveItems = new[] { TestBuilder.LiveItem(TestBuilder.PlayerId, (999, 10)) };
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, PlayersWithTeams(), fixture, liveItems);
+
+        Assert.Empty(finished.TopPerformers);
+    }
+
+    [Fact]
+    public void UnknownPlayerInLiveItems_IsSkipped()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+        var liveItems = new[]
+        {
+            TestBuilder.LiveItem(TestBuilder.PlayerId, (fixture.Id, 8)),
+            TestBuilder.LiveItem(999999, (fixture.Id, 12))
+        };
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, PlayersWithTeams(), fixture, liveItems);
+
+        var only = Assert.Single(finished.TopPerformers);
+        Assert.Equal(TestBuilder.PlayerId, only.Player.Id);
+    }
+
+    [Fact]
+    public void PlayerFromAnotherTeam_IsSkipped()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+        var players = Players(
+            TestBuilder.Player().WithPosition(FplPlayerPosition.Defender).WithTeamId(TestBuilder.HomeTeam().Id),
+            TestBuilder.OtherPlayer().WithPosition(FplPlayerPosition.Midfielder).WithTeamId(99));
+        var liveItems = new[]
+        {
+            TestBuilder.LiveItem(TestBuilder.PlayerId, (fixture.Id, 8)),
+            TestBuilder.LiveItem(TestBuilder.OtherPlayerId, (fixture.Id, 12))
+        };
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, players, fixture, liveItems);
+
+        var only = Assert.Single(finished.TopPerformers);
+        Assert.Equal(TestBuilder.PlayerId, only.Player.Id);
+    }
+
+    [Fact]
+    public void PlayersWithoutPoints_AreExcluded()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+        var liveItems = new[]
+        {
+            TestBuilder.LiveItem(TestBuilder.PlayerId, (fixture.Id, 0)),
+            TestBuilder.LiveItem(TestBuilder.OtherPlayerId, (fixture.Id, 2))
+        };
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, PlayersWithTeams(), fixture, liveItems);
+
+        var only = Assert.Single(finished.TopPerformers);
+        Assert.Equal(TestBuilder.OtherPlayerId, only.Player.Id);
+    }
+
+    [Fact]
+    public void MoreThanTheCap_KeepsTopPlayersAndThoseTiedWithTheLast()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+        var points = new[] { 10, 9, 8, 7, 6, 6, 1 };
+        var players = points.Select((_, i) => new Player { Id = i + 1, WebName = $"player-{i + 1}" }.WithTeamId(TestBuilder.HomeTeam().Id)).ToList();
+        var liveItems = points.Select((p, i) => TestBuilder.LiveItem(i + 1, (fixture.Id, p))).ToList();
+
+        var finished = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, players, fixture, liveItems);
+
+        var topPerformers = finished.TopPerformers.ToList();
+        Assert.Equal(FixtureFulltimeModelBuilder.TopPerformersCount + 1, topPerformers.Count);
+        Assert.Equal(new[] { 10, 9, 8, 7, 6, 6 }, topPerformers.Select(tp => tp.Points).ToArray());
+        Assert.DoesNotContain(topPerformers, tp => tp.Points == 1);
+    }
+
+    [Fact]
+    public void WithoutLiveItems_ReturnsEmptyTopPerformers()
+    {
+        var fixture = TestBuilder.AwayTeamGoal(1, 1).FinishedProvisional();
+
+        var withNull = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, PlayersWithTeams(), fixture);
+        var withEmpty = FixtureFulltimeModelBuilder.CreateFinishedFixture(Teams, PlayersWithTeams(), fixture, new List<LiveItem>());
+
+        Assert.Empty(withNull.TopPerformers);
+        Assert.Empty(withEmpty.TopPerformers);
+    }
+
+    // TestBuilder players only carry a TeamCode. Top performers are matched on TeamId, so set it here.
+    private static ICollection<Player> PlayersWithTeams() => Players(
+        TestBuilder.Player().WithPosition(FplPlayerPosition.Defender).WithTeamId(TestBuilder.HomeTeam().Id),
+        TestBuilder.OtherPlayer().WithPosition(FplPlayerPosition.Midfielder).WithTeamId(TestBuilder.AwayTeam().Id));
+
     private static ICollection<Player> DefaultPlayers() => Players(
         TestBuilder.Player().WithPosition(FplPlayerPosition.Defender),
         TestBuilder.OtherPlayer().WithPosition(FplPlayerPosition.Midfielder));

--- a/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
+++ b/src/FplBot.Tests/Formatting/FulltimeFormattingTests.cs
@@ -153,6 +153,86 @@ public class FulltimeFormattingTests(ITestOutputHelper helper)
         Assert.Equal(string.Empty, output);
     }
 
+    [Fact]
+    public void TopPerformersOnly_ListsPlayersByPointsDescending()
+    {
+        var fixture = GetProvisionalFinishedFixture();
+        fixture.TopPerformers = new[]
+        {
+            TopPerformer("player-B", 9),
+            TopPerformer("player-A", 13),
+            TopPerformer("player-C", 7)
+        };
+
+        var output = Formatter.FormatProvisionalFinished(fixture);
+        helper.WriteLine(output);
+
+        Assert.StartsWith("\nTop performers:\n", output);
+        Assert.DoesNotContain("Bonus points:", output);
+        Assert.DoesNotContain("Defensive contributions:", output);
+        Assert.Equal(new[] { "player-A (13p)", "player-B (9p)", "player-C (7p)" }, Formatter.CreateTopPerformersOutput(fixture));
+    }
+
+    [Fact]
+    public void TopPerformersWithSamePoints_AreOrderedByName()
+    {
+        var fixture = GetProvisionalFinishedFixture();
+        fixture.TopPerformers = new[]
+        {
+            TopPerformer("player-B", 9),
+            TopPerformer("player-A", 9)
+        };
+
+        Assert.Equal(new[] { "player-A (9p)", "player-B (9p)" }, Formatter.CreateTopPerformersOutput(fixture));
+    }
+
+    [Fact]
+    public void AllSections_TopPerformersComeLast()
+    {
+        var fixture = GetProvisionalFinishedFixture(
+            BonusPointsPlayer("player-C", 30),
+            BonusPointsPlayer("player-B", 40),
+            BonusPointsPlayer("player-A", 50));
+        fixture.DefensiveContributions = new[] { DefensiveContributionPlayer("player-D", 11) };
+        fixture.TopPerformers = new[] { TopPerformer("player-A", 13) };
+
+        var output = Formatter.FormatProvisionalFinished(fixture);
+        helper.WriteLine(output);
+
+        var bonusIndex = output.IndexOf("Bonus points:", StringComparison.Ordinal);
+        var dcIndex = output.IndexOf("Defensive contributions:", StringComparison.Ordinal);
+        var tpIndex = output.IndexOf("Top performers:", StringComparison.Ordinal);
+        Assert.True(bonusIndex >= 0);
+        Assert.True(dcIndex > bonusIndex);
+        Assert.True(tpIndex > dcIndex);
+        Assert.Contains("▪️ player-D (11)\n\nTop performers:\n▪️ player-A (13p)", output);
+    }
+
+    [Fact]
+    public void BonusAndTopPerformers_WithoutDefensiveContributions_SeparatedByBlankLine()
+    {
+        var fixture = GetProvisionalFinishedFixture(
+            BonusPointsPlayer("player-C", 30),
+            BonusPointsPlayer("player-B", 40),
+            BonusPointsPlayer("player-A", 50));
+        fixture.TopPerformers = new[] { TopPerformer("player-A", 13) };
+
+        var output = Formatter.FormatProvisionalFinished(fixture);
+        helper.WriteLine(output);
+
+        Assert.DoesNotContain("Defensive contributions:", output);
+        Assert.Contains("▪️ 1p player-C\n\nTop performers:\n▪️ player-A (13p)", output);
+    }
+
+    TopPerformer TopPerformer(string webName, int points)
+    {
+        return new TopPerformer
+        {
+            Player = new Player { WebName = webName },
+            Points = points
+        };
+    }
+
     private FinishedFixture GetProvisionalFinishedFixture(params BonusPointsPlayer[] bonusPointsPlayers)
     {
         return new FinishedFixture

--- a/src/FplBot.Tests/Helpers/TestBuilder.cs
+++ b/src/FplBot.Tests/Helpers/TestBuilder.cs
@@ -358,6 +358,31 @@ public static class TestBuilder
         return player;
     }
 
+    public static Player WithTeamId(this Player player, int teamId)
+    {
+        player.TeamId = teamId;
+        return player;
+    }
+
+    // A live item for a player with one "explain" entry per fixture. The points are spread over two
+    // stats so tests cover the summing of a fixture's stats.
+    public static LiveItem LiveItem(int playerId, params (int FixtureId, int Points)[] fixtures)
+    {
+        return new LiveItem
+        {
+            Id = playerId,
+            Explain = fixtures.Select(f => new LiveItemExplain
+            {
+                Fixture = f.FixtureId,
+                Stats = new List<LiveItemExplainStat>
+                {
+                    new() { Identifier = "minutes", Points = 1, Value = 90 },
+                    new() { Identifier = "bonus", Points = f.Points - 1, Value = f.Points - 1 }
+                }
+            }).ToList()
+        };
+    }
+
     public static Player WithPosition(this Player player, FplPlayerPosition position)
     {
         player.Position = position;

--- a/src/FplBot/Formatting/FinishedFixture.cs
+++ b/src/FplBot/Formatting/FinishedFixture.cs
@@ -10,4 +10,5 @@ public class FinishedFixture
 
     public IEnumerable<BonusPointsPlayer> BonusPoints { get; set; } = new List<BonusPointsPlayer>();
     public IEnumerable<DefensiveContributionPlayer> DefensiveContributions { get; set; } = new List<DefensiveContributionPlayer>();
+    public IEnumerable<TopPerformer> TopPerformers { get; set; } = new List<TopPerformer>();
 }

--- a/src/FplBot/Formatting/Formatter.cs
+++ b/src/FplBot/Formatting/Formatter.cs
@@ -347,6 +347,17 @@ public static class Formatter
             fullTimeReport += $"\nDefensive contributions:\n";
             fullTimeReport += BulletPoints(defensiveContributionsOutput);
         }
+
+        if (fixture.TopPerformers.Any())
+        {
+            var topPerformersOutput = CreateTopPerformersOutput(fixture);
+            if (fullTimeReport.Length > 0)
+            {
+                fullTimeReport += "\n"; // blank line between the previous section and the top performers
+            }
+            fullTimeReport += $"\nTop performers:\n";
+            fullTimeReport += BulletPoints(topPerformersOutput);
+        }
         return fullTimeReport;
     }
 
@@ -356,6 +367,14 @@ public static class Formatter
             .OrderByDescending(dc => dc.Contributions)
             .ThenBy(dc => dc.Player.WebName)
             .Select(dc => $"{dc.Player.WebName} ({dc.Contributions})");
+    }
+
+    public static IEnumerable<string> CreateTopPerformersOutput(FinishedFixture fixture)
+    {
+        return fixture.TopPerformers
+            .OrderByDescending(tp => tp.Points)
+            .ThenBy(tp => tp.Player.WebName)
+            .Select(tp => $"{tp.Player.WebName} ({tp.Points}p)");
     }
 
     static string BonusPointRank(int bonusPoints, IEnumerable<Player> pall)

--- a/src/FplBot/Formatting/Helpers/FixtureFulltimeModelBuilder.cs
+++ b/src/FplBot/Formatting/Helpers/FixtureFulltimeModelBuilder.cs
@@ -5,7 +5,10 @@ namespace FplBot.Formatting.Helpers;
 
 public static class FixtureFulltimeModelBuilder
 {
-    public static FinishedFixture CreateFinishedFixture(ICollection<Team> teams, ICollection<Player> players, Fixture n)
+    // Number of players listed under "Top performers". Players tied with the last one are kept as well.
+    public const int TopPerformersCount = 5;
+
+    public static FinishedFixture CreateFinishedFixture(ICollection<Team> teams, ICollection<Player> players, Fixture n, ICollection<LiveItem>? liveItems = null)
     {
         return new FinishedFixture
         {
@@ -13,8 +16,60 @@ public static class FixtureFulltimeModelBuilder
             HomeTeam = teams.First(t => t.Id == n.HomeTeamId),
             AwayTeam = teams.First(t => t.Id == n.AwayTeamId),
             BonusPoints = CreateBonusPlayers(players, n),
-            DefensiveContributions = CreateDefensiveContributionPlayers(players, n)
+            DefensiveContributions = CreateDefensiveContributionPlayers(players, n),
+            TopPerformers = CreateTopPerformers(players, n, liveItems)
         };
+    }
+
+    // The live endpoint (event/{gw}/live) reports, per player, an "explain" breakdown with the points earned
+    // in each fixture of the gameweek. Summing the entry for this fixture gives the player's points for this
+    // match alone, which keeps double gameweeks correct. The points are provisional at this stage, just like
+    // the bonus points and defensive contributions.
+    private static IEnumerable<TopPerformer> CreateTopPerformers(ICollection<Player> players, Fixture fixture, ICollection<LiveItem>? liveItems)
+    {
+        try
+        {
+            if (liveItems == null || liveItems.Count == 0)
+                return new List<TopPerformer>();
+
+            var ranked = liveItems
+                .Select(ToTopPerformer)
+                .Where(tp => tp != null && tp.Points > 0)
+                .Select(tp => tp!)
+                .OrderByDescending(tp => tp.Points)
+                .ThenBy(tp => tp.Player.WebName)
+                .ToList();
+
+            if (ranked.Count <= TopPerformersCount)
+                return ranked;
+
+            var cutoff = ranked[TopPerformersCount - 1].Points;
+            return ranked.Where(tp => tp.Points >= cutoff).ToList();
+
+            TopPerformer? ToTopPerformer(LiveItem item)
+            {
+                var explain = item.Explain.FirstOrDefault(e => e.Fixture == fixture.Id);
+                if (explain == null)
+                    return null;
+
+                var player = players.FirstOrDefault(p => p.Id == item.Id);
+                if (player == null)
+                    return null;
+
+                if (player.TeamId != fixture.HomeTeamId && player.TeamId != fixture.AwayTeamId)
+                    return null;
+
+                return new TopPerformer
+                {
+                    Player = player,
+                    Points = explain.Stats.Sum(s => s.Points)
+                };
+            }
+        }
+        catch
+        {
+            return new List<TopPerformer>();
+        }
     }
 
     private static IEnumerable<BonusPointsPlayer> CreateBonusPlayers(ICollection<Player> players, Fixture fixture)

--- a/src/FplBot/Formatting/TopPerformer.cs
+++ b/src/FplBot/Formatting/TopPerformer.cs
@@ -1,0 +1,9 @@
+using Fpl.Client.Models;
+
+namespace FplBot.Formatting;
+
+public class TopPerformer
+{
+    public Player Player { get; set; } = null!;
+    public int Points { get; set; }
+}

--- a/src/FplBot/Integrations/Fpl/Models/LiveItem.cs
+++ b/src/FplBot/Integrations/Fpl/Models/LiveItem.cs
@@ -11,10 +11,26 @@ public class LiveItem
 {
     public int Id { get; set; }
     public LiveItemStat? Stats { get; set; }
+    public ICollection<LiveItemExplain> Explain { get; set; } = [];
 }
 
 public class LiveItemStat
 {
     [JsonPropertyName("total_points")]
     public int TotalPoints { get; set; }
+}
+
+// Per-fixture points breakdown. A player has one entry per fixture played in the gameweek,
+// so a double gameweek player has two.
+public class LiveItemExplain
+{
+    public int Fixture { get; set; }
+    public ICollection<LiveItemExplainStat> Stats { get; set; } = [];
+}
+
+public class LiveItemExplainStat
+{
+    public string? Identifier { get; set; }
+    public int Points { get; set; }
+    public int Value { get; set; }
 }

--- a/src/FplBot/Services/EventHandlers/Discord/DiscordFixtureFulltimeHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Discord/DiscordFixtureFulltimeHandler.cs
@@ -13,7 +13,8 @@ public class DiscordFixtureFulltimeHandler(
     IGuildRepository teamRepo,
     ILogger<DiscordFixtureFulltimeHandler> logger,
     IGlobalSettingsClient settingsClient,
-    IFixtureClient fixtureClient)
+    IFixtureClient fixtureClient,
+    ILiveClient liveClient)
     : IConsumer<FixtureFinished>
 {
     private readonly ILogger<DiscordFixtureFulltimeHandler> _logger = logger;
@@ -25,7 +26,10 @@ public class DiscordFixtureFulltimeHandler(
         var settings = await settingsClient.GetGlobalSettings();
         var fixtures = await fixtureClient.GetFixtures() ?? new List<Fpl.Client.Models.Fixture>();
         var fplfixture = fixtures.FirstOrDefault(f => f.Id == message.FixtureId)!;
-        var fixture = FixtureFulltimeModelBuilder.CreateFinishedFixture(settings?.Teams ?? new List<Fpl.Client.Models.Team>(), settings?.Players ?? new List<Fpl.Client.Models.Player>(), fplfixture);
+        var liveItems = fplfixture.Event.HasValue
+            ? await liveClient.GetLiveItems(fplfixture.Event.Value, isOngoingGameweek: true)
+            : null;
+        var fixture = FixtureFulltimeModelBuilder.CreateFinishedFixture(settings?.Teams ?? new List<Fpl.Client.Models.Team>(), settings?.Players ?? new List<Fpl.Client.Models.Player>(), fplfixture, liveItems);
         var title = $"*FT: {fixture.HomeTeam.ShortName} {fixture.Fixture.HomeTeamScore}-{fixture.Fixture.AwayTeamScore} {fixture.AwayTeam.ShortName}*";
         var threadMessage = Formatter.FormatProvisionalFinished(fixture);
         foreach (var sub in subs)

--- a/src/FplBot/Services/EventHandlers/Slack/SlackFixtureFulltimeHandler.cs
+++ b/src/FplBot/Services/EventHandlers/Slack/SlackFixtureFulltimeHandler.cs
@@ -16,7 +16,8 @@ public class SlackFixtureFulltimeHandler(
     ISlackTeamRepository slackTeamRepo,
     ILogger<SlackFixtureFulltimeHandler> logger,
     IGlobalSettingsClient settingsClient,
-    IFixtureClient fixtureClient)
+    IFixtureClient fixtureClient,
+    ILiveClient liveClient)
     : IConsumer<FixtureFinished>, IConsumer<PublishFulltimeMessageToSlackWorkspace>
 {
     public async Task Consume(ConsumeContext<FixtureFinished> context)
@@ -27,7 +28,10 @@ public class SlackFixtureFulltimeHandler(
         var settings = await settingsClient.GetGlobalSettings();
         var fixtures = await fixtureClient.GetFixtures() ?? new List<Fpl.Client.Models.Fixture>();
         var fplfixture = fixtures.FirstOrDefault(f => f.Id == message.FixtureId)!;
-        var fixture = FixtureFulltimeModelBuilder.CreateFinishedFixture(settings?.Teams ?? new List<Fpl.Client.Models.Team>(), settings?.Players ?? new List<Fpl.Client.Models.Player>(), fplfixture);
+        var liveItems = fplfixture.Event.HasValue
+            ? await liveClient.GetLiveItems(fplfixture.Event.Value, isOngoingGameweek: true)
+            : null;
+        var fixture = FixtureFulltimeModelBuilder.CreateFinishedFixture(settings?.Teams ?? new List<Fpl.Client.Models.Team>(), settings?.Players ?? new List<Fpl.Client.Models.Player>(), fplfixture, liveItems);
         var title = $"*FT: {fixture.HomeTeam.ShortName} {fixture.Fixture.HomeTeamScore}-{fixture.Fixture.AwayTeamScore} {fixture.AwayTeam.ShortName}*";
         var threadMessage = Formatter.FormatProvisionalFinished(fixture);
 


### PR DESCRIPTION
Closes #373

Appends a "Top performers" section after the defensive contributions in the provisional full time thread message, listing the players with the most FPL points in the match. Both the Slack and Discord full time handlers pick it up through the shared model builder and formatter.

```
*FT: ARS 2-1 CHE*

Bonus points:
▪️ 3p Saka
▪️ 2p Ødegaard
▪️ 1p Palmer

Defensive contributions:
▪️ Caicedo (14)
▪️ Rice (12)

Top performers:
▪️ Saka (13p)
▪️ Ødegaard (9p)
▪️ Palmer (7p)
▪️ Rice (6p)
▪️ Caicedo (5p)
```

## How it works

- **Data source:** the live endpoint (`event/{gw}/live`) via the existing `ILiveClient`, reading the per-fixture `explain` breakdown rather than the gameweek total from bootstrap-static. Only the points earned in this fixture are summed, which keeps double gameweeks correct. `LiveItem` gains an `Explain` property for it.
- **Cap:** the top five players, sorted by points then name. Anyone tied with the fifth is kept as well, so a tie is never cut.
- **Robustness:** players without points, players not in the match and unknown player ids are skipped. A null or empty live response simply omits the section, so a hiccup on the live endpoint never breaks the FT message.
- **Provisional:** `FixtureFinished` fires on `FinishedProvisional`, so the points are provisional at this stage, in line with the bonus points and defensive contributions already shown.

No new `EventSubscription`; this extends the existing `FixtureFullTime` notification. `ILiveClient` was already registered app-wide, so the handlers only gain a constructor parameter.

## Tests

- `FulltimeFormattingTests`: section ordering, blank line between sections, ordering by points then name.
- `FixtureFulltimeModelBuilderTests`: double gameweek only counts this fixture, unknown player and other-team player skipped, zero-point players excluded, tie at the cap keeps all tied players, null and empty live items give an empty section.

Note: the change was written in a cloud session without a .NET SDK available, so CI on this PR is the first build and test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)