### PR TITLE
fix: resolve vite/plugin-vue peer dependency conflict, add CI frontend build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
-      - name: Test
-        run: dotnet run --project src/Build -- test
+      - name: CI
+        run: dotnet run --project src/Build -- ci --parallel

--- a/src/Build/Program.cs
+++ b/src/Build/Program.cs
@@ -10,9 +10,17 @@ var infoVersion = Env("INFOVERSION", version);
 var targets = new Targets();
 
 targets.Add("test",
-    "Run all tests (self-contained — no external Redis or ASB required)",
+    "Run all tests",
     async () => await Command.RunAsync("dotnet",
         """test src -p:TreatWarningsAsErrors=true --logger "GitHubActions;report-warnings=false" """));
+
+targets.Add("client-build",
+    "Install dependencies and build the WebApi ClientApp",
+    async () => await BuildClientApp());
+
+targets.Add("ci",
+    "Run tests and build the client app (used by CI)",
+    ["test", "client-build"]);
 
 targets.Add("docker-build",
     "Build the Docker image once and tag it locally for all process types",

--- a/src/FplBot/Services/WebApi/ClientApp/package-lock.json
+++ b/src/FplBot/Services/WebApi/ClientApp/package-lock.json
@@ -12,7 +12,7 @@
         "vue-router": "^4.3.0"
       },
       "devDependencies": {
-        "@vitejs/plugin-vue": "^5.0.4",
+        "@vitejs/plugin-vue": "^6.0.8",
         "typescript": "^5.4.5",
         "vite": "^8.2.2",
         "vue-tsc": "^2.0.7"
@@ -361,16 +361,19 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
-      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+      "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
       }
     },

--- a/src/FplBot/Services/WebApi/ClientApp/package.json
+++ b/src/FplBot/Services/WebApi/ClientApp/package.json
@@ -14,7 +14,7 @@
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.0.4",
+    "@vitejs/plugin-vue": "^6.0.8",
     "typescript": "^5.4.5",
     "vite": "^8.2.2",
     "vue-tsc": "^2.0.7"


### PR DESCRIPTION
## Summary
- Dependabot bumped `vite` to `^8.2.2`, but `@vitejs/plugin-vue@5.2.4` only supports vite `^5.0.0 || ^6.0.0`, breaking `npm ci` in the `docker-build` Bullseye target (seen failing in deploy-to-test: https://github.com/fplbot/fplbot/actions/runs/34353229129/job/102471375094).
- Bumped `@vitejs/plugin-vue` to `^6.0.8`, which supports vite `^8.0.0`.
- Added a `ci` Bullseye target (`test` + `client-build`, run with `--parallel`) and wired it into `CI.yml`, so the frontend build is exercised on every push/PR instead of only during deploy-to-test — this class of break will now fail fast in CI.

## Test plan
- [x] CI passes
- [x] Heroku test logs clean after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)