### PR TITLE
Remove Monday-only schedule from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
     "config:recommended"
   ],
   "timezone": "Europe/Oslo",
-  "schedule": ["before 6am on Monday"],
   "prHourlyLimit": 5,
   "prConcurrentLimit": 10,
   "labels": ["dependencies"],


### PR DESCRIPTION
## Summary
- Renovate PRs were all sitting in "Awaiting Schedule" because updates were restricted to run only before 6am on Mondays. Removes that restriction so Renovate opens PRs as soon as it detects updates.

## Test plan
- [ ] Confirm Renovate picks up the config change and starts opening the queued PRs listed in the Dependency Dashboard (#371)