### PR TITLE
fix: move to .NET 11 RC to match the SDK actually available on build machines

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -25,19 +25,17 @@ and any services unrelated to your change alone.
 ```bash
 dotnet build --no-incremental src/FplBot/FplBot.csproj
 cd src/FplBot
-ASPNETCORE_ENVIRONMENT=Development ./bin/Debug/net10.0/FplBot --services WebApi > /tmp/webapi.log 2>&1 &
-DOTNET_ENVIRONMENT=Development   ./bin/Debug/net10.0/FplBot --services EventHandlers > /tmp/eventhandlers.log 2>&1 &
+DOTNET_ENVIRONMENT=Development ./bin/Debug/net11.0/FplBot --services WebApi > /tmp/webapi.log 2>&1 &
+DOTNET_ENVIRONMENT=Development ./bin/Debug/net11.0/FplBot --services EventHandlers > /tmp/eventhandlers.log 2>&1 &
 ```
 
-**Gotcha:** WebApi runs as a `WebApplication` (reads `ASPNETCORE_ENVIRONMENT`). EventHandlers/
-EventPublishers/SearchIndexer run as a generic `Host` via `Host.CreateDefaultBuilder`
-(`FplBotApplication.RunAsWorkerHost`), which reads `DOTNET_ENVIRONMENT` instead. Set both env vars
-when you need Development behavior across services, or check the "Hosting environment: ..." line
-in the startup log to confirm which one landed.
+`DOTNET_ENVIRONMENT` is all you need across every service, including WebApi — don't bother with
+`ASPNETCORE_ENVIRONMENT`. Check the "Hosting environment: ..." line in the startup log to confirm
+it landed.
 
 There is no `appsettings.Development.json` — dev safety comes from `env.IsDevelopment()` checks in
-code (dev-logging Slack/Discord client wrappers), not config overrides. Default `ASPNETCORE_ENVIRONMENT`/
-`DOTNET_ENVIRONMENT` when unset is `Production`.
+code (dev-logging Slack/Discord client wrappers), not config overrides. Default `DOTNET_ENVIRONMENT`
+when unset is `Production`.
 
 ## Redis access
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "11.0.x"
+          dotnet-quality: "preview"
       - name: CI
         run: dotnet run --project src/Build -- ci --parallel

--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -16,7 +16,8 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "11.0.x"
+          dotnet-quality: "preview"
       - uses: actions/setup-node@v7
         with:
           node-version: "24"

--- a/.github/workflows/DeployToTest.yml
+++ b/.github/workflows/DeployToTest.yml
@@ -21,7 +21,8 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "11.0.x"
+          dotnet-quality: "preview"
       - uses: actions/setup-node@v7
         with:
           node-version: "24"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:11.0
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-rc.1
 WORKDIR /app
 COPY . /app
 ENTRYPOINT ["dotnet", "FplBot.dll"]

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFramework>net11.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/FplBot/FplBot.csproj
+++ b/src/FplBot/FplBot.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- The .NET 10 SDK is no longer installed locally/in CI (only 11.0 RC is), so publishes required a 10.0.0 runtime the deployed Heroku containers didn't have — every dyno crash-looped on startup, causing `/debug` to 503.
- Bumps `FplBot`/`FplBot.Tests` to `net11.0`, pins the Dockerfile base image to the matching `aspnet:11.0.0-rc.1` runtime, and points CI/deploy workflows at the `11.0.x` preview SDK.
- Fixes the `verify` skill's stale `net10.0` paths and drops its `ASPNETCORE_ENVIRONMENT` guidance (`DOTNET_ENVIRONMENT` covers every service, including WebApi).

## Test plan
- [x] Local build (`dotnet build src --no-incremental`) — 0 warnings, 0 errors
- [x] `dotnet run --project src/Build -- test` — 218 passed, 4 skipped
- [x] `dotnet run --project src/Build -- docker-build` — succeeded, verified the built image resolves the .NET runtime correctly
- [x] CI passes
- [x] Heroku test logs clean after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)