### PR TITLE
chore: trim CORS to actually-live origins, rename policy

### DIFF
--- a/src/FplBot.Tests/ApiEndpoints/CorsValidatorTests.cs
+++ b/src/FplBot.Tests/ApiEndpoints/CorsValidatorTests.cs
@@ -5,14 +5,13 @@ namespace FplBot.Tests.ApiEndpoints;
 public class CorsValidatorTests
 {
     [Theory]
-    [InlineData("http://localhost:3000", true)]
-    [InlineData("https://fplbot-frontend.herokuapp.com", true)]
+    [InlineData("http://localhost:5162", true)]
+    [InlineData("https://localhost:1337", true)]
     [InlineData("https://www.fplbot.app", true)]
-    [InlineData("https://fplbotfrontend-pr-4.herokuapp.com", true)]
-    [InlineData("https://fplbotfrontend-pr-12.herokuapp.com", true)]
-    [InlineData("https://someotherdomain-pr-12.herokuapp.com", false)]
-    [InlineData("https://www.fplsearch.com", true)]
-    [InlineData("https://fplsearch.com", true)]
+    [InlineData("https://test.fplbot.app", true)]
+    [InlineData("https://evil.example.com", false)]
+    [InlineData("http://www.fplbot.app", false)] // wrong scheme
+    [InlineData("https://fplbot.app", true)] // bare apex domain, no www
     public void ValidatesOrigins(string origin, bool expectedResult)
     {
         var isValid = CorsOriginValidator.ValidateOrigin(origin);

--- a/src/FplBot/Services/WebApi/Infrastructure/CorsOriginValidator.cs
+++ b/src/FplBot/Services/WebApi/Infrastructure/CorsOriginValidator.cs
@@ -1,33 +1,22 @@
-using System.Text.RegularExpressions;
-
 namespace FplBot.WebApi.Infrastructure;
 
 public static class CorsOriginValidator
 {
-    public const string CustomCorsPolicyName = "CustomDynamicHerokuReviewAppsCompliantCorsPolicy";
+    public const string CorsPolicyName = "AllowedOriginsCorsPolicy";
 
     public static List<string> FixedOrigins =
     [
-        "http://localhost:3000",
+        "http://localhost:5162",
 
-        "https://fplbot-frontend.herokuapp.com",
-
-        "https://fplbot-frontend-test.herokuapp.com",
+        "https://localhost:1337",
 
         "https://www.fplbot.app",
 
-        "https://test.fplbot.app",
+        "https://fplbot.app",
 
-        "https://www.fplsearch.com",
-
-        "https://fplsearch.com"
+        "https://test.fplbot.app"
     ];
 
-    private static readonly Regex HerokuReviewAppsOriginRegex = new Regex("https:\\/\\/fplbotfrontend-pr-\\d+.herokuapp.com");
-
-    public static bool ValidateOrigin(string origin)
-    {
-        var isAFixedEnv = FixedOrigins.Any(o => o.Equals(origin, StringComparison.InvariantCultureIgnoreCase));
-        return isAFixedEnv || HerokuReviewAppsOriginRegex.IsMatch(origin);
-    }
+    public static bool ValidateOrigin(string origin) =>
+        FixedOrigins.Any(o => o.Equals(origin, StringComparison.InvariantCultureIgnoreCase));
 }

--- a/src/FplBot/Services/WebApi/Infrastructure/WebAppExtensions.cs
+++ b/src/FplBot/Services/WebApi/Infrastructure/WebAppExtensions.cs
@@ -45,7 +45,7 @@ public static class WebAppExtensions
             FileProvider = wwwrootProvider
         });
         app.UseRouting();
-        app.UseCors(CorsOriginValidator.CustomCorsPolicyName);
+        app.UseCors(CorsOriginValidator.CorsPolicyName);
         app.UseCookiePolicy();
         app.UseAuthentication();
         app.UseAuthorization();
@@ -58,9 +58,9 @@ public static class WebAppExtensions
         );
 
         var api = app.MapGroup("/api");
-        FplEndpoints.Map(api.MapGroup("/fpl").RequireCors(CorsOriginValidator.CustomCorsPolicyName));
-        SearchEndpoints.Map(api.MapGroup("/search").RequireCors(CorsOriginValidator.CustomCorsPolicyName));
-        InstallUrlEndpoints.Map(api.MapGroup("/oauth").RequireCors(CorsOriginValidator.CustomCorsPolicyName));
+        FplEndpoints.Map(api.MapGroup("/fpl").RequireCors(CorsOriginValidator.CorsPolicyName));
+        SearchEndpoints.Map(api.MapGroup("/search").RequireCors(CorsOriginValidator.CorsPolicyName));
+        InstallUrlEndpoints.Map(api.MapGroup("/oauth").RequireCors(CorsOriginValidator.CorsPolicyName));
 
         // Two separate /admin groups on purpose: login/logout/me carry mixed per-route auth
         // (see AdminAuthEndpoints), while everything else requires the IsAdmin policy as a

--- a/src/FplBot/Services/WebApi/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/FplBot/Services/WebApi/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -203,7 +203,7 @@ public static class WebApplicationBuilderExtensions
 
         services.AddCors(options =>
         {
-            options.AddPolicy(CorsOriginValidator.CustomCorsPolicyName, p =>
+            options.AddPolicy(CorsOriginValidator.CorsPolicyName, p =>
                 p.SetIsOriginAllowed(CorsOriginValidator.ValidateOrigin).AllowAnyHeader().AllowAnyMethod());
         });
 


### PR DESCRIPTION
## Summary
- Trims the CORS allowlist down to origins that are actually in use: the Vite dev server (`localhost:5162`), the backend itself (`localhost:1337`, for direct API testing), and `fplbot.app`/`test.fplbot.app` (with and without `www`). Drops the old `fplbot-frontend*.herokuapp.com`, `fplsearch.com`, and the Heroku-review-apps regex — that separate frontend project no longer exists.
- Renames `CustomCorsPolicyName` → `CorsPolicyName` (value `AllowedOriginsCorsPolicy`) since the old name/value referenced the now-removed Heroku-review-apps behavior.
- CORS itself is intentionally kept (not removed) — it's the browser-side allowlist blocking any other origin from reading `/api/search`, `/api/fpl`, `/api/oauth` responses.

## Test plan
- [x] CI passes
- [ ] Heroku test logs clean after deploy (deploy-to-test only runs on push to main, so this can only be checked post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)