### PR TITLE
fix: resolve Redis and Elasticsearch Unhealthy status in Aspire dashboard

### DIFF
--- a/src/FplBot.AppHost/DevSeederLifecycleHook.cs
+++ b/src/FplBot.AppHost/DevSeederLifecycleHook.cs
@@ -111,7 +111,7 @@ internal static class DevSeeder
         try
         {
             Console.WriteLine("[DevSeeder] Starting Elasticsearch seed...");
-            using var http = new HttpClient { BaseAddress = new Uri("http://localhost:9201") };
+            using var http = new HttpClient { BaseAddress = new Uri("http://localhost:9200") };
             http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(
                 "Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes("elastic:dev")));
 

--- a/src/FplBot.AppHost/Program.cs
+++ b/src/FplBot.AppHost/Program.cs
@@ -2,8 +2,8 @@ using AlmostServiceBus.Aspire.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var redis = builder.AddRedis("redis", port: 6379)
-    .WithArgs("--requirepass", "devpassword");
+var redisPassword = builder.AddParameter("redis-password", "devpassword", secret: true);
+var redis = builder.AddRedis("redis", port: 6379, password: redisPassword);
 builder.AddServiceBusEmulator("servicebus", dashboardPort:20000, port: 6000);
 var elasticsearch = builder.AddElasticsearch("elasticsearch",
         password: builder.AddParameter("elasticsearch-password", "dev", secret: true), port: 9201);

--- a/src/FplBot.AppHost/Program.cs
+++ b/src/FplBot.AppHost/Program.cs
@@ -6,7 +6,8 @@ var redisPassword = builder.AddParameter("redis-password", "devpassword", secret
 var redis = builder.AddRedis("redis", port: 6379, password: redisPassword);
 builder.AddServiceBusEmulator("servicebus", dashboardPort:20000, port: 6000);
 var elasticsearch = builder.AddElasticsearch("elasticsearch",
-        password: builder.AddParameter("elasticsearch-password", "dev", secret: true), port: 9201);
+        password: builder.AddParameter("elasticsearch-password", "dev", secret: true), port: 9200)
+    .WithEndpoint("internal", e => e.Port = 9300);
 
 builder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>(redis.Resource, DevSeeder.SeedAsync);
 builder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>(elasticsearch.Resource, DevSeeder.SeedElasticsearchAsync);

--- a/src/FplBot/appsettings.json
+++ b/src/FplBot/appsettings.json
@@ -31,7 +31,7 @@
     "AllowedUserIds": ""
   },
   "search": {
-    "IndexUri": "http://localhost:9201",
+    "IndexUri": "http://localhost:9200",
     "Username": "elastic",
     "Password": "dev",
     "EntriesIndex": "entries-index",


### PR DESCRIPTION
## Summary
- Redis and Elasticsearch showed Unhealthy in the local Aspire dashboard even though both were actually running fine — a password mismatch for Redis, a port collision for Elasticsearch.
- Both fixed; dashboard now reports both healthy.

## Test plan
- [x] CI passes
- [x] Build/tests green locally; app verified running against the fixed local Redis/Elasticsearch

🤖 Generated with [Claude Code](https://claude.com/claude-code)