### PR TITLE
feat: migrate FplBot.Tests to xunit v3 on Microsoft Testing Platform

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/Build/Program.cs
+++ b/src/Build/Program.cs
@@ -12,7 +12,7 @@ var targets = new Targets();
 targets.Add("test",
     "Run all tests",
     async () => await Command.RunAsync("dotnet",
-        """test src -p:TreatWarningsAsErrors=true --logger "GitHubActions;report-warnings=false" """));
+        "test src -p:TreatWarningsAsErrors=true --report-gh"));
 
 targets.Add("client-build",
     "Install dependencies and build the WebApi ClientApp",

--- a/src/FplBot.Tests/Data/RedisIntegrationTests.cs
+++ b/src/FplBot.Tests/Data/RedisIntegrationTests.cs
@@ -21,7 +21,7 @@ public class RedisIntegrationTests(ITestOutputHelper helper) : IAsyncLifetime
     private DiscordGuildStore _guildStore = null!;
     private TokenStore _store = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _redisContainer.StartAsync();
 
@@ -40,7 +40,7 @@ public class RedisIntegrationTests(ITestOutputHelper helper) : IAsyncLifetime
         _guildStore = new DiscordGuildStore(multiplexer, discordOpts, new SimpleLogger(helper));
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         _server?.FlushDatabase();
         await _redisContainer.DisposeAsync();
@@ -205,7 +205,7 @@ public class RedisIntegrationTests(ITestOutputHelper helper) : IAsyncLifetime
         ]));
 
         foreach(var key in _server.Keys(pattern: "GuildSubs-Guild2-Channel-*")) {
-            helper.WriteLine(key);
+            helper.WriteLine(key.ToString() ?? string.Empty);
         }
 
         var subs = await _guildRepo.GetAllGuildSubscriptions();

--- a/src/FplBot.Tests/E2E/Health/AdminHealthEndpointsTests.cs
+++ b/src/FplBot.Tests/E2E/Health/AdminHealthEndpointsTests.cs
@@ -31,14 +31,14 @@ public class AdminHealthEndpointsTests(ElasticsearchFixture elastic)
         // outage, not a fake IConnectionMultiplexer — while leaving the shared Elasticsearch
         // fixture untouched so only the Redis dependency flips to unhealthy.
         var redisContainer = new RedisBuilder("redis:latest").Build();
-        await redisContainer.StartAsync();
+        await redisContainer.StartAsync(TestContext.Current.CancellationToken);
         var redis = await ConnectionMultiplexer.ConnectAsync(redisContainer.GetConnectionString());
 
         var beforeStop = await AdminHealthEndpoints.GetDependencyHealth(redis, elastic.Client);
         var beforeStopOk = Assert.IsType<Ok<DependencyHealthResponse>>(beforeStop);
         Assert.True(beforeStopOk.Value!.Healthy, DescribeFailures(beforeStopOk.Value));
 
-        await redisContainer.StopAsync();
+        await redisContainer.StopAsync(TestContext.Current.CancellationToken);
 
         var result = await AdminHealthEndpoints.GetDependencyHealth(redis, elastic.Client);
 

--- a/src/FplBot.Tests/E2E/Search/AdminSearchEndpointsTests.cs
+++ b/src/FplBot.Tests/E2E/Search/AdminSearchEndpointsTests.cs
@@ -38,8 +38,8 @@ public class AdminSearchEndpointsTests(ElasticsearchFixture elastic)
             Query("messi", "203.0.113.9", "Web"),
             Query("messi", "U999", "Slack"),
             Query("ronaldo", "203.0.113.9", "Web"),
-        ], index);
-        await elastic.Client.Indices.RefreshAsync(index);
+        ], index, TestContext.Current.CancellationToken);
+        await elastic.Client.Indices.RefreshAsync(index, ct: TestContext.Current.CancellationToken);
 
         var result = await AdminSearchEndpoints.GetSearchAnalytics(7, 20, service);
 
@@ -57,8 +57,8 @@ public class AdminSearchEndpointsTests(ElasticsearchFixture elastic)
             Query("messi", "203.0.113.5", "Web"),
             Query("ronaldo", "203.0.113.5", "Web"),
             Query("messi", "U999", "Slack"), // actor is a Slack user id, not an IP — must be excluded
-        ], index);
-        await elastic.Client.Indices.RefreshAsync(index);
+        ], index, TestContext.Current.CancellationToken);
+        await elastic.Client.Indices.RefreshAsync(index, ct: TestContext.Current.CancellationToken);
 
         var result = await AdminSearchEndpoints.GetSearchAnalytics(7, 20, service);
 
@@ -76,8 +76,8 @@ public class AdminSearchEndpointsTests(ElasticsearchFixture elastic)
             Query("ronaldo", "U111", "Slack"),
             Query("messi", "U222", "Slack"),
             Query("messi", "203.0.113.5", "Web"), // actor is an IP, not a Slack user id — must be excluded
-        ], index);
-        await elastic.Client.Indices.RefreshAsync(index);
+        ], index, TestContext.Current.CancellationToken);
+        await elastic.Client.Indices.RefreshAsync(index, ct: TestContext.Current.CancellationToken);
 
         var result = await AdminSearchEndpoints.GetSearchAnalytics(7, 20, service);
 
@@ -96,8 +96,8 @@ public class AdminSearchEndpointsTests(ElasticsearchFixture elastic)
         await elastic.Client.IndexManyAsync([
             Query("recent", "203.0.113.5", "Web", DateTime.UtcNow.AddDays(-1)),
             Query("ancient", "203.0.113.5", "Web", DateTime.UtcNow.AddDays(-100)),
-        ], index);
-        await elastic.Client.Indices.RefreshAsync(index);
+        ], index, TestContext.Current.CancellationToken);
+        await elastic.Client.Indices.RefreshAsync(index, ct: TestContext.Current.CancellationToken);
 
         var result = await AdminSearchEndpoints.GetSearchAnalytics(7, 20, service);
 

--- a/src/FplBot.Tests/E2E/Search/ElasticsearchFixture.cs
+++ b/src/FplBot.Tests/E2E/Search/ElasticsearchFixture.cs
@@ -16,7 +16,7 @@ public class ElasticsearchFixture : IAsyncLifetime
 
     public IElasticClient Client { get; private set; } = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _container.StartAsync();
 
@@ -27,7 +27,7 @@ public class ElasticsearchFixture : IAsyncLifetime
         Client = new ElasticClient(settings);
     }
 
-    public async Task DisposeAsync() => await _container.DisposeAsync();
+    public async ValueTask DisposeAsync() => await _container.DisposeAsync();
 }
 
 [CollectionDefinition("Elasticsearch")]

--- a/src/FplBot.Tests/E2E/Search/SearchEndpointsTests.cs
+++ b/src/FplBot.Tests/E2E/Search/SearchEndpointsTests.cs
@@ -60,8 +60,8 @@ public class SearchEndpointsTests(ElasticsearchFixture elastic)
     {
         var (service, options, _) = NewSearchService();
         var entry = new EntryItem { Id = 42, RealName = "Messi" };
-        await elastic.Client.IndexAsync(entry, i => i.Index(options.EntriesIndex).Id(entry.Id));
-        await elastic.Client.Indices.RefreshAsync(options.EntriesIndex);
+        await elastic.Client.IndexAsync(entry, i => i.Index(options.EntriesIndex).Id(entry.Id), TestContext.Current.CancellationToken);
+        await elastic.Client.Indices.RefreshAsync(options.EntriesIndex, ct: TestContext.Current.CancellationToken);
 
         var result = await SearchEndpoints.GetEntry(42, service);
 
@@ -73,7 +73,7 @@ public class SearchEndpointsTests(ElasticsearchFixture elastic)
     public async Task GetEntry_NotFound_ReturnsNotFound()
     {
         var (service, options, _) = NewSearchService();
-        await elastic.Client.Indices.CreateAsync(options.EntriesIndex);
+        await elastic.Client.Indices.CreateAsync(options.EntriesIndex, ct: TestContext.Current.CancellationToken);
 
         var result = await SearchEndpoints.GetEntry(1, service);
 
@@ -100,8 +100,8 @@ public class SearchEndpointsTests(ElasticsearchFixture elastic)
     public async Task GetEntries_PageBeyondResultsAndNoHits_ReturnsBadRequest()
     {
         var (service, options, _) = NewSearchService();
-        await elastic.Client.Indices.CreateAsync(options.EntriesIndex);
-        await elastic.Client.Indices.RefreshAsync(options.EntriesIndex);
+        await elastic.Client.Indices.CreateAsync(options.EntriesIndex, ct: TestContext.Current.CancellationToken);
+        await elastic.Client.Indices.RefreshAsync(options.EntriesIndex, ct: TestContext.Current.CancellationToken);
 
         var result = await SearchEndpoints.GetEntries("nobody", 5, HttpContextWithRemoteIp(), service);
 
@@ -143,8 +143,8 @@ public class SearchEndpointsTests(ElasticsearchFixture elastic)
     public async Task GetLeagues_PageBeyondResultsAndNoHits_ReturnsBadRequest()
     {
         var (service, options, _) = NewSearchService();
-        await elastic.Client.Indices.CreateAsync(options.LeaguesIndex);
-        await elastic.Client.Indices.RefreshAsync(options.LeaguesIndex);
+        await elastic.Client.Indices.CreateAsync(options.LeaguesIndex, ct: TestContext.Current.CancellationToken);
+        await elastic.Client.Indices.RefreshAsync(options.LeaguesIndex, ct: TestContext.Current.CancellationToken);
 
         var result = await SearchEndpoints.GetLeagues("nobody", 5, "", HttpContextWithRemoteIp(), service);
 

--- a/src/FplBot.Tests/E2E/Slack/EventHandlerFixture.cs
+++ b/src/FplBot.Tests/E2E/Slack/EventHandlerFixture.cs
@@ -34,7 +34,7 @@ public class EventHandlerFixture : IAsyncLifetime
     public SlackMessageCapture SlackCapture { get; } = new();
     public TokenStore Store { get; private set; } = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _redis.StartAsync();
 
@@ -128,7 +128,7 @@ public class EventHandlerFixture : IAsyncLifetime
         await server.FlushAllDatabasesAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/FplBot.Tests/E2E/Slack/SlackEventHandlerE2ETests.cs
+++ b/src/FplBot.Tests/E2E/Slack/SlackEventHandlerE2ETests.cs
@@ -9,14 +9,14 @@ public class SlackEventHandlerE2ETests(EventHandlerFixture fixture, ITestOutputH
 {
     public required string _teamId;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _teamId = Guid.NewGuid().ToString("N");
         fixture.SlackCapture.Reset();
         await fixture.FlushRedisAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task InjuryUpdate_WorkspaceSubscribedToInjuryUpdates_ReceivesSlackMessage()
@@ -28,7 +28,7 @@ public class SlackEventHandlerE2ETests(EventHandlerFixture fixture, ITestOutputH
                 new InjuredPlayer(1, "Salah", 25.0, new TeamDescription(14, "LIV", "Liverpool")),
                 new InjuryStatus("a", ""),
                 new InjuryStatus("d", "Knee injury"))
-        ]));
+        ]), TestContext.Current.CancellationToken);
 
         var msg = await fixture.SlackCapture.WaitForMessageAsync();
         output.WriteLine($"Received: {msg.Text}");
@@ -47,7 +47,7 @@ public class SlackEventHandlerE2ETests(EventHandlerFixture fixture, ITestOutputH
                 new InjuredPlayer(1, "Salah", 25.0, new TeamDescription(14, "LIV", "Liverpool")),
                 new InjuryStatus("a", ""),
                 new InjuryStatus("d", "Knee injury"))
-        ]));
+        ]), TestContext.Current.CancellationToken);
 
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
             fixture.SlackCapture.WaitForMessageAsync(timeout: TimeSpan.FromMilliseconds(500)));
@@ -67,7 +67,7 @@ public class SlackEventHandlerE2ETests(EventHandlerFixture fixture, ITestOutputH
                 OwnershipPercentage: 30.5,
                 TeamId: 11,
                 TeamShortName: "MCI")
-        ]));
+        ]), TestContext.Current.CancellationToken);
 
         var msg = await fixture.SlackCapture.WaitForMessageAsync();
         output.WriteLine($"Received: {msg.Text}");
@@ -90,7 +90,7 @@ public class SlackEventHandlerE2ETests(EventHandlerFixture fixture, ITestOutputH
                 OwnershipPercentage: 30.5,
                 TeamId: 11,
                 TeamShortName: "MCI")
-        ]));
+        ]), TestContext.Current.CancellationToken);
 
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
             fixture.SlackCapture.WaitForMessageAsync(timeout: TimeSpan.FromMilliseconds(500)));
@@ -110,7 +110,7 @@ public class SlackEventHandlerE2ETests(EventHandlerFixture fixture, ITestOutputH
                 new InjuredPlayer(1, "Salah", 25.0, new TeamDescription(14, "LIV", "Liverpool")),
                 new InjuryStatus("a", ""),
                 new InjuryStatus("d", "Knee injury"))
-        ]));
+        ]), TestContext.Current.CancellationToken);
 
         var msg = await fixture.SlackCapture.WaitForMessageAsync();
         output.WriteLine($"Received: {msg.Text}");

--- a/src/FplBot.Tests/FplBot.Tests.csproj
+++ b/src/FplBot.Tests/FplBot.Tests.csproj
@@ -2,6 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>net11.0</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
         <IsPackable>false</IsPackable>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -9,17 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0" />
+        <PackageReference Include="xunit.v3" Version="4.0.0" />
         <PackageReference Include="FakeItEasy" Version="9.0.1" />
         <PackageReference Include="Bogus" Version="35.6.5" />
         <PackageReference Include="Testcontainers.Redis" Version="4.15.0" />
@@ -56,7 +49,6 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="Xunit.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FplBot.Tests/Helpers/XUnitTestOutputLogger.cs
+++ b/src/FplBot.Tests/Helpers/XUnitTestOutputLogger.cs
@@ -6,7 +6,7 @@ public class XUnitTestOutputLogger<T>(ITestOutputHelper? helper = null) : ILogge
 {
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        helper?.WriteLine(state?.ToString());
+        helper?.WriteLine(state?.ToString() ?? string.Empty);
     }
 
     public bool IsEnabled(LogLevel logLevel)


### PR DESCRIPTION
## Summary
- Replaces xunit v2 + VSTest (Microsoft.NET.Test.Sdk, xunit.runner.visualstudio, coverlet.collector, GitHubActionsTestLogger) with xunit.v3 running natively on Microsoft Testing Platform (MTP), opted in via `global.json` + `UseMicrosoftTestingPlatformRunner`.
- Fixes the resulting API breaks (`IAsyncLifetime` → `ValueTask`, `ITestOutputHelper` namespace move, xunit v3 analyzer's `TestContext.Current.CancellationToken` requirement) and swaps the GitHub Actions test reporter for the first-party `Microsoft.Testing.Extensions.GitHubActionsReport` (`--report-gh`).
- Coverage collection (`coverlet.collector`) is dropped rather than replaced, since CI wasn't actually invoking coverage collection before either.

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)