### PR TITLE
fix: fake IGlobalSettingsClient in Factory.cs instead of hitting the live FPL API

### DIFF
--- a/src/FplBot.Tests/Helpers/Factory.cs
+++ b/src/FplBot.Tests/Helpers/Factory.cs
@@ -1,4 +1,8 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using FakeItEasy;
+using Fpl.Client.Abstractions;
+using Fpl.Client.Models;
 using FplBot.Data;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -67,6 +71,14 @@ public static class Factory
 
         SlackClient = A.Fake<ISlackClient>();
         services.Replace<IPublishEndpoint>(PublishEndpoint = new TestPublishEndpoint());
+
+        // Real FPL API clients otherwise hit the live fantasy.premierleague.com API on every
+        // Handle() call — slow (multi-second) and non-deterministic. Fake GetGlobalSettings()
+        // from a real, locally-embedded bootstrap-static snapshot instead (mirrors EventHandlerFixture).
+        var globalSettings = JsonSerializer.Deserialize<GlobalSettings>(
+            TestResources.Boostrap_Static_Json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web) { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+        services.Replace<IGlobalSettingsClient>(GlobalSettingsClientBuilder.Returning(globalSettings));
 
         services.AddSingleton(hostEnvironment);
         services.AddFplWorkers();


### PR DESCRIPTION
## Summary
- `Factory.cs`'s `BuildServiceProvider` (used by every SlackAppMentions command-handler unit test) never faked `IGlobalSettingsClient`, so `.Handle()` calls made a real HTTPS request to `fantasy.premierleague.com/api/bootstrap-static/` (~1.7MB) every time, with no cross-test caching (a fresh empty `AddDistributedMemoryCache()` per test-class instantiation guaranteed a cache miss every call). Measured in CI: 7.59s/7.30s for single tests.
- Fakes it from the same real, locally-embedded `bootstrap-static.json` snapshot `EventHandlerFixture` already uses via `GlobalSettingsClientBuilder` — removes both the multi-second cost and the live-API flakiness/non-determinism risk.

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)